### PR TITLE
Add staging CI/CD workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,108 @@
+name: Staging Deployment (AWS App Runner)
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: staging-aws
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ansari-backend
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Deploy to App Runner
+        id: deploy-apprunner
+        uses: awslabs/amazon-app-runner-deploy@main
+        env:
+          ENVIRONMENT: staging
+          DATABASE_URL: ${{ format('{0}{1}', secrets.SSM_ROOT, 'database-url') }}
+          SECRET_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'secret-key') }}
+          ORIGINS:  ${{ format('{0}{1}', secrets.SSM_ROOT, 'origins') }}
+
+          OPENAI_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'openai-api-key') }}
+          SENDGRID_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'sendgrid-api-key') }}
+          ANTHROPIC_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'anthropic-api-key') }}
+          KALEMAT_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'kalemat-api-key') }}
+          SUNNAH_TOKEN: ${{ format('{0}{1}', secrets.SSM_ROOT, 'sunnah-token') }}
+          VECTARA_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'vectara-api-key') }}
+          TAFSIR_VECTARA_CORPUS_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'tafsir-vectara-corpus-key') }}
+          MAWSUAH_VECTARA_CORPUS_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mawsuah-vectara-corpus-key') }}
+          QURAN_DOT_COM_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'quran-dot-com-api-key') }}
+
+          WHATSAPP_ACCESS_TOKEN_FROM_SYS_USER: ${{ format('{0}{1}', secrets.SSM_ROOT, 'whatsapp-access-token-from-sys-user') }}
+          WHATSAPP_BUSINESS_PHONE_NUMBER_ID: ${{ format('{0}{1}', secrets.SSM_ROOT, 'whatsapp-business-phone-number-id') }}
+          WHATSAPP_VERIFY_TOKEN_FOR_WEBHOOK: ${{ format('{0}{1}', secrets.SSM_ROOT, 'whatsapp-verify-token-for-webhook') }}
+
+          WHATSAPP_RECIPIENT_WAID: ${{ format('{0}{1}', secrets.SSM_ROOT, 'whatsapp-recipient-waid') }}
+          WHATSAPP_API_VERSION: ${{ format('{0}{1}', secrets.SSM_ROOT, 'whatsapp-api-version') }}
+          WHATSAPP_TEST_BUSINESS_PHONE_NUMBER_ID: ${{ format('{0}{1}', secrets.SSM_ROOT, 'whatsapp-test-business-phone-number-id') }}
+          ZROK_SHARE_TOKEN: ${{ format('{0}{1}', secrets.SSM_ROOT, 'zrok-share-token') }}
+
+        with:
+          service: ansari-staging-backend
+          image: ${{ steps.build-image.outputs.image }}
+          access-role-arn: ${{ secrets.ROLE_ARN }}
+          region: ${{ secrets.AWS_REGION }}
+          cpu : 1
+          memory : 2
+          port: 8000
+          wait-for-service-stability-seconds: 1200
+          copy-env-vars: |
+            ENVIRONMENT
+          copy-secret-env-vars: |
+            DATABASE_URL
+            SECRET_KEY
+            ORIGINS
+
+            OPENAI_API_KEY
+            SENDGRID_API_KEY
+            ANTHROPIC_API_KEY
+            KALEMAT_API_KEY
+            SUNNAH_TOKEN
+            VECTARA_API_KEY
+            TAFSIR_VECTARA_CORPUS_KEY
+            MAWSUAH_VECTARA_CORPUS_KEY
+            QURAN_DOT_COM_API_KEY
+
+            WHATSAPP_ACCESS_TOKEN_FROM_SYS_USER
+            WHATSAPP_BUSINESS_PHONE_NUMBER_ID
+            WHATSAPP_VERIFY_TOKEN_FOR_WEBHOOK
+
+            WHATSAPP_RECIPIENT_WAID
+            WHATSAPP_API_VERSION
+            WHATSAPP_TEST_BUSINESS_PHONE_NUMBER_ID
+            ZROK_SHARE_TOKEN
+          instance-role-arn: ${{ secrets.INSTANCE_ROLE_ARN }}
+
+      - name: App Runner URL
+        run: echo "App runner URL ${{ steps.deploy-apprunner.outputs.service-url }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.13
+
+WORKDIR /app/
+
+COPY requirements.txt /app/
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY /src /app/src
+
+ENV PYTHONPATH=/app/src
+
+CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "ansari.app.main_api:app"]


### PR DESCRIPTION
This PR introduces a standalone backend staging environment which complements the frontend staging environment created earlier. 

We now have an end to end isolated environment for testing, the staging frontend CI/CD pipeline (centralized in Expo) has been updated to use the staging backend as shown below.

![image](https://github.com/user-attachments/assets/273313b2-9637-4f62-a577-25ca45d4221b)


![image](https://github.com/user-attachments/assets/6062e477-bb59-4162-8106-50604b3d5975)

To prepare for this update, I have made the following changes to the repo:
1. Created a develop branch and set it as the default branch.
2. Added a ruleset that requires at least one reviewer before allowing merging to take place.
3. Merged the user ID changes from integer to UUID into the develop branch.
4. This PR introduces a workflow that will be triggered on pushes to the develop branch to deploy to the staging environment.

Team members will need to do the following changes to their fork:
1. Create a new develop branch based on the upstream version, then set it as the default branch.

![image](https://github.com/user-attachments/assets/c3a4a793-a97e-4021-898e-e85237c2b917)

2. Open the Actions section from the repo settings and disable actions as the deployment actions will fail at the fork level due to missing secrets.

![image](https://github.com/user-attachments/assets/d024279b-fd34-46a1-9f24-1f82fb5a3dad)

Regarding the deployment process, this update uses AWS App Runner which is likely to change down the line as Waleed prefers Google Cloud over AWS but this is a quick setup for the time being.

The process goes as follows:
1. A dockerfile has been created which creates the working directory, installs the dependencies,  copies the required files over and specifies the launch command.
2. On pushes to the develop branch, a docker container is built then uploaded to a private container registry then deployeod to AWS App Runner (a managed container runtime).
3. Environment secrets are stored natively inside AWS, the GitHub workflow supplies references to the location of the variables which are then supplied at runtime.

Environment Setup
I hav created a single environment 'staging-aws' that hosts the secrets required by the deployment process, I haven't added any secrets or changed any values at the global scope (repo level).

![image](https://github.com/user-attachments/assets/fd930f84-e961-48f7-baea-fbc793efd4b7)

There are 6 secrets used by the workflow that specify the AWS account used, the region (currently set to us-west-2) and the IAM roles that provide the permissions required to access various resources during deployment and runtime.

![image](https://github.com/user-attachments/assets/02192ad5-1a15-425a-8277-5600e3503814)

You can easily override these values to use your own AWS account or remove the whole environment altogether and move to another service provider.

The actual environment variables are stored as secure strings inside AWS Systems Manager.

![image](https://github.com/user-attachments/assets/5a680e0b-3663-463c-92f3-58f002e7d6d0)

The workflow references them using the full paramater path.

![image](https://github.com/user-attachments/assets/bf20c09e-ff5d-440e-994b-cf2622c43805)

Then they are passed over through the 'copy-secret-env-vars' which signals to the App Runner runtime that it needs to obtain the actual values from a secure store.

![image](https://github.com/user-attachments/assets/bb21cb09-724f-44a8-b973-2068a879e75a)

The staging environment API is available at https://staging-api.ansari.chat/

Note:
The codebase currently uses requirements.txt without specifying specific dependency versions, this can produce unpredictable results as the depedency versions are not locked.

I would recommend moving over to the uv package manager utilising uv.lock and drop requirements.txt entirely.

The GitHub dependabot team is currently working to add support for uv so it might be a good time to move over.
https://github.com/dependabot/dependabot-core/issues/10478