### PR TITLE
Add multilingual citation support to prevent duplicate translations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,15 @@
 - **Logging**: Use the logger from `ansari.ansari_logger.get_logger()`
 - **Documentation**: Add docstrings to functions, especially complex ones
 - **Testing**: Create unit tests in `tests/unit/` and integration tests in `tests/integration/`
+- **Test-first development**: Always write tests before shipping features
+  - Write tests that validate both expected behavior and edge cases
+  - When fixing bugs, first write a test that reproduces the issue
+  - Run tests frequently during development to catch regressions
+
+## Testing Best Practices
+- Run tests before committing: `pytest tests/`
+- Run specific test categories: `pytest tests/unit/` or `pytest tests/integration/`
+- Add tests for new functionality in the appropriate directory
+- Use fixture factories to keep tests maintainable
+- Test both happy path and error conditions
+- Keep tests independent (no dependencies between test functions)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ psycopg2-binary
 pydantic_settings
 pyjwt
 pytest-asyncio
+pytest-mock
 rich
 sendgrid
 setuptools

--- a/src/ansari/agents/ansari.py
+++ b/src/ansari/agents/ansari.py
@@ -85,11 +85,11 @@ class Ansari:
         for m in self.process_message_history(use_tool=True):
             if m:
                 yield m
-                
+
         # Ensure we always get a final response (like AnsariClaude)
         if len(self.message_history) > 0 and self.message_history[-1]["role"] != "assistant":
             logger.debug("Last message is not from assistant, making a follow-up call")
-            
+
             # Search tool will have been used by now, so generate a final response
             for m in self.process_one_round(use_tool=False):
                 if m:
@@ -355,7 +355,7 @@ class Ansari:
             raise json.JSONDecodeError
         except KeyError as e:
             logger.error(f"Missing key in tool args: {e} - Tool args: {tool_args}")
-            query = "" 
+            query = ""
 
         tool_instance = self.tool_name_to_instance[tool_name]
         logger.debug(f"Running {tool_name} with query: {query}")
@@ -363,13 +363,14 @@ class Ansari:
             # Get raw results directly using run() instead of run_as_list()
             raw_results = tool_instance.run(query)
             logger.debug(f"Raw results type: {type(raw_results)}")
-            
+
             # Format the results as a list of strings
             results = tool_instance.format_as_list(raw_results)
             logger.debug(f"Formatted results type: {type(results)}")
             logger.debug(f"Results sample: {str(results)[:200] if results else 'Empty results'}")
         except Exception as e:
             import traceback
+
             logger.error(f"Error running {tool_name}: {str(e)}")
             logger.error(f"Traceback: {traceback.format_exc()}")
             # Return an error message as results
@@ -390,11 +391,12 @@ class Ansari:
             ],
         }
         self.message_history.append(internal_msg)
-        
+
         # Log the assistant's tool call message
         if self.message_logger is not None:
-            self.message_logger.log("assistant", "", tool_name, 
-                {"function": tool_definition, "id": tool_id, "type": "function"})
+            self.message_logger.log(
+                "assistant", "", tool_name, {"function": tool_definition, "id": tool_id, "type": "function"}
+            )
 
         if len(results) == 0:
             # corner case where the api returns no results
@@ -417,13 +419,13 @@ class Ansari:
             elif not all(isinstance(item, str) for item in results):
                 logger.warning("Not all results are strings, converting to strings")
                 results = [str(item) for item in results]
-            
+
             results_str = msg_prefix + "\nAnother relevant citation:\n".join(results)
         except Exception as e:
             logger.error(f"Error joining results: {str(e)}")
             logger.error(f"Results that caused error: {results}")
             results_str = f"Error processing results: {str(e)}"
-        
+
         msg_generated_from_tool = {
             "role": "tool",
             "content": results_str,

--- a/src/ansari/ansari_db.py
+++ b/src/ansari/ansari_db.py
@@ -938,7 +938,7 @@ class AnsariDB:
         elif role == "assistant":
             # For assistant messages, always use block format
             content_blocks = []
-            
+
             # Add text block
             if isinstance(content, str):
                 content_blocks.append({"type": "text", "text": content})
@@ -948,7 +948,7 @@ class AnsariDB:
             else:
                 # Convert to text block
                 content_blocks.append({"type": "text", "text": str(content)})
-            
+
             # If there's tool info, add tool use block
             if tool_name and tool_details:
                 try:
@@ -957,17 +957,12 @@ class AnsariDB:
                     tool_input = tool_details_dict.get("args")
                     # Add tool use block only if we have valid information
                     if tool_id and tool_name:
-                        content_blocks.append({
-                            "type": "tool_use", 
-                            "id": tool_id, 
-                            "name": tool_name, 
-                            "input": tool_input
-                        })
+                        content_blocks.append({"type": "tool_use", "id": tool_id, "name": tool_name, "input": tool_input})
                 except json.JSONDecodeError:
                     logger.warning(f"Failed to parse tool details JSON: {tool_details}")
-            
+
             return [{"role": role, "content": content_blocks}]
-            
+
         # Handle regular user messages without tool use
         else:
             # For simple user messages, use simple format

--- a/src/ansari/ansari_logger.py
+++ b/src/ansari/ansari_logger.py
@@ -16,31 +16,30 @@ def get_logger(name: str) -> logging.Logger:
         logging.Logger: Configured logger instance.
     """
     logging_level = get_settings().LOGGING_LEVEL.upper()
-    
+
     # Create a logger
     logger = logging.getLogger(name)
-    
+
     # Clear any existing handlers to avoid duplicate logs
     if logger.handlers:
         logger.handlers.clear()
-    
+
     # Set the logging level
     logger.setLevel(logging_level)
-    
+
     # Create console handler
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(logging_level)
-    
+
     # Create formatter
     formatter = logging.Formatter(
-        '%(asctime)s | %(levelname)s | %(name)s:%(funcName)s:%(lineno)d | %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        "%(asctime)s | %(levelname)s | %(name)s:%(funcName)s:%(lineno)d | %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
-    
+
     # Add formatter to handler
     console_handler.setFormatter(formatter)
-    
+
     # Add handler to logger
     logger.addHandler(console_handler)
-    
+
     return logger

--- a/src/ansari/examples/test_search_mawsuah.py
+++ b/src/ansari/examples/test_search_mawsuah.py
@@ -13,54 +13,56 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from src.ansari.tools.search_mawsuah import SearchMawsuah
 from src.ansari.config import get_settings
 
+
 def main():
     """Test the SearchMawsuah class."""
     # Get settings
     settings = get_settings()
-    
+
     # Create a SearchMawsuah instance
     sm = SearchMawsuah(
         vectara_api_key=settings.VECTARA_API_KEY.get_secret_value(),
         vectara_corpus_key=settings.MAWSUAH_VECTARA_CORPUS_KEY,
     )
-    
+
     # Test basic search
     print("Testing basic search...")
     query = "prayer"
     results = sm.run(query, num_results=2)
-    
+
     # Check if results are in the expected format
     print(f"Results type: {type(results)}")
-    
+
     # If search_results is present, the parent class's API format is being used correctly
     if "search_results" in results:
         print(f"Found {len(results['search_results'])} search results")
-        
+
         # Test format_as_list
         print("\nTesting format_as_list...")
         text_results = sm.format_as_list(results)
         print(f"format_as_list produced {len(text_results)} results")
-        
+
         # Test format_as_ref_list
         print("\nTesting format_as_ref_list...")
         ref_list = sm.format_as_ref_list(results)
         print(f"format_as_ref_list produced {len(ref_list)} documents")
-        
+
         # Check if translation worked in ref_list
         if ref_list and not isinstance(ref_list[0], str):
             text = ref_list[0]["source"]["data"]
             print("First document text includes translation:", "English:" in text)
-        
+
         # Test run_as_string
         print("\nTesting run_as_string...")
         string_results = sm.run_as_string(query, num_results=2)
         print(f"run_as_string output length: {len(string_results)}")
         print("run_as_string output includes translation:", "English Translation:" in string_results)
-        
+
         print("\nSearchMawsuah works correctly and inherits properly from SearchVectara!")
     else:
         print("ERROR: Results don't have search_results key. API format mismatch.")
         print(f"Results keys: {results.keys()}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/ansari/tools/search_hadith.py
+++ b/src/ansari/tools/search_hadith.py
@@ -1,5 +1,6 @@
 import requests
 import logging
+from ansari.util.translation import format_multilingual_data
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -83,22 +84,27 @@ class SearchHadith:
             ar_text = result.get("ar_text", "")
             grade = result.get("grade_en", "").strip()
 
-            # Create citation title
+            # Create citation title (including grade if available)
             title = (
                 f"{source_book} - Chapter {chapter}: {chapter_name}, "
                 f"Section {section_number}: {section_name}, Hadith {hadith}, LK id {id}"
             )
-
-            # Complete text of hadith with grade
-            data = f"English Text: {text}"
-            if ar_text:
-                data = f"Arabic Text: {ar_text}\n\n{data}"
             if grade:
-                data = f"{data}\n\nGrade: {grade}"
+                title += f" (Grade: {grade})"
+
+            # Prepare multilingual data for hadith content
+            text_entries = {}
+            if ar_text:
+                text_entries["ar"] = ar_text
+            if text:
+                text_entries["en"] = text
+
+            # Convert to JSON format for multilingual support
+            multilingual_data = format_multilingual_data(text_entries)
 
             document = {
                 "type": "document",
-                "source": {"type": "text", "media_type": "text/plain", "data": data},
+                "source": {"type": "text", "media_type": "text/plain", "data": multilingual_data},
                 "title": title,
                 "context": "Retrieved from hadith collections",
                 "citations": {"enabled": True},

--- a/src/ansari/tools/search_mawsuah.py
+++ b/src/ansari/tools/search_mawsuah.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, List, Any
 from ansari.tools.search_vectara import SearchVectara
+from ansari.util.translation import format_multilingual_data
 
 TOOL_NAME = "search_mawsuah"
 
@@ -30,83 +31,81 @@ class SearchMawsuah(SearchVectara):
                     "You will translate this query into Arabic.",
                 }
             ],
-            required_params=["query"]
+            required_params=["query"],
         )
-            
+
     def format_as_ref_list(self, response: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Format raw API results as a list of reference documents for Claude.
         Each reference will include only the original Arabic text for efficiency.
         The English translation will be added later only for the parts that are cited.
-        
+
         Args:
             response: The raw API response from Vectara
-            
+
         Returns:
             A list of reference documents formatted for Claude with Arabic text
         """
         # Get base documents from parent class
         documents = super().format_as_ref_list(response)
-        
+
         if not documents:
             return ["No results found."]
-        
+
         # Update documents with just Arabic text and citation support
         for doc in documents:
             if isinstance(doc, str):
                 continue
-                
+
             # Keep only the Arabic text and remove HTML tags
             text = doc["source"]["data"]
             text = text.replace("<em>", "").replace("</em>", "")
-            doc["source"]["data"] = text
+
+            # Convert to multilingual format (Arabic only)
+            # Note: Mawsuah only returns results in Arabic, so we only have Arabic text here.
+            # The English translation will be added later by AnsariClaude when a citation is actually used.
+            doc["source"]["data"] = format_multilingual_data({"ar": text})
             doc["title"] = "Encyclopedia of Islamic Jurisprudence"
             doc["citations"] = {"enabled": True}
-                
+
         return documents
 
     def format_as_tool_result(self, response: Dict[str, Any]) -> Dict[str, Any]:
         """
         Format raw API results as a tool result dictionary for Claude.
-        
+
         Args:
             response: The raw API response from Vectara
-            
+
         Returns:
             A tool result dictionary with formatted results
         """
         # Get base tool result from parent class
         result = super().format_as_tool_result(response)
-        
+
         # If no results were found, return as is
         if not result.get("results", []):
-            return {
-                "type": "text",
-                "text": "No results found."
-            }
-        
-        return {
-            "type": "text",
-            "text": "Please see the references below."
-        }
+            return {"type": "text", "text": "No results found."}
+
+        return {"type": "text", "text": "Please see the references below."}
 
     def run_as_string(self, query: str, num_results: int = 10, **kwargs) -> str:
         """Return results as a human-readable string with Arabic text only."""
         # Get the response using the parent's run method
         response = self.run(query, num_results, **kwargs)
-        
+
         # Handle no results case
         if not response.get("search_results"):
             return "No results found."
-        
+
         # Process results
         results = []
         for i, result in enumerate(response.get("search_results", [])):
             arabic_text = result.get("text", "").replace("<em>", "").replace("</em>", "")
-            
-            entry = f"Entry {i+1}:\n"
+
+            entry = f"Entry {i + 1}:\n"
             entry += f"Arabic Text: {arabic_text}\n"
-            
+
             results.append(entry)
-                
+
         return "\n\n".join(results)

--- a/src/ansari/tools/search_quran.py
+++ b/src/ansari/tools/search_quran.py
@@ -1,5 +1,6 @@
 import requests
 from ansari.ansari_logger import get_logger
+from ansari.util.translation import format_multilingual_data
 
 logger = get_logger(__name__)
 KALEMAT_BASE_URL = "https://api.kalimat.dev/search"
@@ -65,12 +66,12 @@ class SearchQuran:
         # Added debug logging to understand the ayah structure
         logger.debug(f"Ayah data type: {type(ayah)}")
         logger.debug(f"Ayah content: {str(ayah)[:200]}")
-        
+
         # Handle if ayah is not a dictionary
         if not isinstance(ayah, dict):
             logger.error(f"Expected ayah to be a dict but got {type(ayah)}")
             return f"Error: Invalid ayah format - {str(ayah)[:100]}..."
-            
+
         try:
             ayah_num = ayah["id"]
             ayah_ar = ayah.get("text", "Not retrieved")
@@ -104,13 +105,14 @@ class SearchQuran:
             # Create citation title
             title = f"Quran {id}"
 
-            # Combine Arabic and English text
-            text = f"Arabic: {arabic}\nEnglish: {english}"
+            # Format as multilingual data with both Arabic and English
+            # Note: Quran search results already include both Arabic and English translations
+            multilingual_data = format_multilingual_data({"ar": arabic, "en": english})
 
             documents.append(
                 {
                     "type": "document",
-                    "source": {"type": "text", "media_type": "text/plain", "data": text},
+                    "source": {"type": "text", "media_type": "text/plain", "data": multilingual_data},
                     "title": title,
                     "context": "Retrieved from the Holy Quran",
                     "citations": {"enabled": True},
@@ -139,7 +141,7 @@ class SearchQuran:
     def run_as_list(self, query: str, num_results: int = 10):
         logger.info(f'Searching quran for "{query}"')
         results = self.run(query, num_results)
-        logger.debug(f'Results from API: {type(results)}')
+        logger.debug(f"Results from API: {type(results)}")
         try:
             # Use the direct approach from the original implementation
             formatted_results = []
@@ -149,9 +151,10 @@ class SearchQuran:
             return formatted_results
         except Exception as e:
             import traceback
-            logger.error(f'Error formatting results: {str(e)}')
-            logger.error(f'Full traceback: {traceback.format_exc()}')
-            logger.error(f'Results that caused error: {results}')
+
+            logger.error(f"Error formatting results: {str(e)}")
+            logger.error(f"Full traceback: {traceback.format_exc()}")
+            logger.error(f"Results that caused error: {results}")
             return [f"Error processing results: {str(e)} - {traceback.format_exc()}"]
 
     def run_as_string(self, query: str, num_results: int = 10):
@@ -159,5 +162,5 @@ class SearchQuran:
         try:
             return "\n".join([self.pp_ayah(r) for r in results])
         except Exception as e:
-            logger.error(f'Error formatting results as string: {str(e)}')
+            logger.error(f"Error formatting results as string: {str(e)}")
             return f"Error processing results: {str(e)}"

--- a/src/ansari/tools/search_tafsir_encyc.py
+++ b/src/ansari/tools/search_tafsir_encyc.py
@@ -60,7 +60,7 @@ class SearchTafsirEncyc(SearchUsul):
                 },
             },
         }
-        
+
     def format_as_list(self, results: Dict[str, Any]) -> List[str]:
         """Format raw results as a list of strings.
 
@@ -89,13 +89,13 @@ class SearchTafsirEncyc(SearchUsul):
                 if "metadata" in node:
                     metadata = node["metadata"]
                     node_id = metadata.get("bookId", "Unknown")
-                    
+
                     # Extract page and volume information
                     if "pages" in metadata and len(metadata["pages"]) > 0:
                         page = metadata["pages"][0]
                         page_info = page.get("page", "Unknown")
                         volume_info = page.get("volume", "")
-                        
+
                     # Extract chapter information
                     if "chapters" in metadata and len(metadata["chapters"]) > 0:
                         chapter = metadata["chapters"][0]
@@ -106,7 +106,7 @@ class SearchTafsirEncyc(SearchUsul):
                 node_id = result.get("nodeId", "Unknown")
                 page_info = result.get("page", "Unknown")
                 volume_info = ""
-                
+
                 if "chapter" in result:
                     chapter_info = result["chapter"].get("title", "")
                 else:
@@ -120,18 +120,18 @@ class SearchTafsirEncyc(SearchUsul):
                 parts.append(f"Page: {page_info}")
             if node_id:
                 parts.append(f"ID: {node_id}")
-            
+
             header = ", ".join(parts)
-            
+
             if chapter_info:
                 formatted_text = f"{header}\nChapter: {chapter_info}\n\n{text}"
             else:
                 formatted_text = f"{header}\n\n{text}"
-                
+
             formatted_results.append(formatted_text)
 
         return formatted_results if formatted_results else ["No results found."]
-    
+
     def format_as_ref_list(self, results: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Format raw results as a list of reference documents for Claude.
 
@@ -149,7 +149,7 @@ class SearchTafsirEncyc(SearchUsul):
         for result in results.get("results", []):
             # Extract score if available
             score = result.get("score", None)
-            
+
             # Extract data from the result
             if "node" in result:
                 node = result["node"]
@@ -162,13 +162,13 @@ class SearchTafsirEncyc(SearchUsul):
                 if "metadata" in node:
                     metadata = node["metadata"]
                     metadata.get("bookId", "Unknown")
-                    
+
                     # Extract page and volume information
                     if "pages" in metadata and len(metadata["pages"]) > 0:
                         page = metadata["pages"][0]
                         page_info = page.get("page", "Unknown")
                         volume_info = page.get("volume", "")
-                        
+
                     # Extract chapter information
                     if "chapters" in metadata and len(metadata["chapters"]) > 0:
                         chapter = metadata["chapters"][0]
@@ -179,7 +179,7 @@ class SearchTafsirEncyc(SearchUsul):
                 result.get("nodeId", "Unknown")
                 page_info = result.get("page", "Unknown")
                 volume_info = ""
-                
+
                 if "chapter" in result:
                     chapter_info = result["chapter"].get("title", "")
                 else:
@@ -195,9 +195,9 @@ class SearchTafsirEncyc(SearchUsul):
             # Add chapter info to the title if available
             if chapter_info:
                 title_parts.append(f"Chapter: {chapter_info}")
-                
+
             title = ", ".join(title_parts)
-            
+
             # Content is just the text
             data = text
 
@@ -207,48 +207,46 @@ class SearchTafsirEncyc(SearchUsul):
                 context += f" (Relevance score: {score:.2f})"
 
             # Create the document object
-            documents.append({
-                "type": "document",
-                "source": {
-                    "type": "text", 
-                    "media_type": "text/plain", 
-                    "data": data
-                },
-                "title": title,
-                "context": context,
-                "citations": {"enabled": True}
-            })
+            documents.append(
+                {
+                    "type": "document",
+                    "source": {"type": "text", "media_type": "text/plain", "data": data},
+                    "title": title,
+                    "context": context,
+                    "citations": {"enabled": True},
+                }
+            )
 
         return documents if documents else ["No results found."]
-    
+
     def _ref_object_to_string(self, ref_obj: Dict[str, Any]) -> str:
         """Convert a reference object to a string representation.
-        
+
         Args:
             ref_obj: A reference object
-            
+
         Returns:
             String representation of the reference
         """
         if isinstance(ref_obj, str):
             return ref_obj
-        
+
         if "type" not in ref_obj or ref_obj["type"] != "document":
             # Handle old format or unexpected format
             return str(ref_obj)
-        
+
         # Extract data from the document object
         title = ref_obj.get("title", "")
         data = ""
         if "source" in ref_obj and "data" in ref_obj["source"]:
             data = ref_obj["source"]["data"]
-        
+
         # Format as string
         result = f"Node ID: {title}\n"
         result += f"Text: {data}\n"
-        
+
         return result
-        
+
     def run_as_string(self, query: str, limit: int = 10, page: int = 1, include_chapters: bool = True) -> str:
         """Run search and return results as a single string.
 
@@ -263,12 +261,12 @@ class SearchTafsirEncyc(SearchUsul):
         """
         results = self.run(query, limit, page, include_chapters)
         ref_objects = self.format_as_ref_list(results)
-        
+
         # Convert each reference object to a string
         string_results = [self._ref_object_to_string(ref_obj) for ref_obj in ref_objects]
-        
+
         return "\n".join(string_results)
-        
+
     def format_as_tool_result(self, results: Dict[str, Any]) -> Dict[str, Any]:
         """Format raw results as a tool result for Claude based on structured references.
 
@@ -279,36 +277,33 @@ class SearchTafsirEncyc(SearchUsul):
             Dict containing formatted results for Claude
         """
         formatted_refs = self.format_as_ref_list(results)
-        
+
         # Check if we have actual results or just a "no results" message
         if len(formatted_refs) == 1 and isinstance(formatted_refs[0], str):
             return {"type": "text", "text": formatted_refs[0]}
-            
+
         # Otherwise, convert each reference to a tool result item
         formatted_items = []
         for ref in formatted_refs:
             # Create a text representation for the tool result
             text = self._ref_object_to_string(ref)
-            
-            formatted_items.append({
-                "type": "text",
-                "text": text
-            })
-            
+
+            formatted_items.append({"type": "text", "text": text})
+
         return {"type": "array", "items": formatted_items}
-        
+
     def format_tool_response(self, results: Dict[str, Any]) -> str:
         """Format a message about the results for tool response.
-        
+
         Args:
             results: Raw results from run()
-            
+
         Returns:
             A message describing the results
         """
         if not results or "results" not in results or not results.get("results", []):
             return "No results found for your query in the Encyclopedia of Quranic Interpretation."
-            
+
         count = len(results.get("results", []))
         return (
             f"Found {count} relevant passage(s) in the Encyclopedia of Quranic Interpretation. "

--- a/src/ansari/util/translation.py
+++ b/src/ansari/util/translation.py
@@ -1,8 +1,9 @@
 # Translation utility for Ansari using Claude models
 
 import anthropic
-from typing import Optional
+from typing import Dict, Optional
 import asyncio
+import json
 
 from ansari.ansari_logger import get_logger
 from ansari.config import get_settings
@@ -12,40 +13,37 @@ logger = get_logger(__name__)
 
 
 def translate_text(
-    text: str, 
-    target_lang: str, 
-    source_lang: Optional[str] = None,
-    model: str = "claude-3-5-haiku-20241022"
+    text: str, target_lang: str, source_lang: Optional[str] = None, model: str = "claude-3-5-haiku-20241022"
 ) -> str:
     """Translates text using Claude models, defaulting to latest Haiku.
-    
+
     Args:
         text (str): The text to translate
         target_lang (str): Target language code (e.g., "ar", "en") or name (e.g., "Arabic", "English")
         source_lang (Optional[str], optional): Source language code or name. If None, auto-detected.
         model (str, optional): Claude model to use. Defaults to "claude-3-5-haiku-20241022".
-        
+
     Returns:
         str: The translated text
-        
+
     Raises:
         Exception: If translation fails
     """
     if not text:
         return ""
-        
+
     # Get settings and initialize Anthropic client
     settings = get_settings()
     client = anthropic.Anthropic(api_key=settings.ANTHROPIC_API_KEY.get_secret_value())
-    
+
     # Detect source language if not provided
     if not source_lang:
         source_lang = get_language_from_text(text)
-        
+
     # Return original text if target language is the same as source
     if source_lang == target_lang:
         return text
-    
+
     try:
         # Call Claude for translation
         response = client.messages.create(
@@ -56,38 +54,94 @@ def translate_text(
                 "You are a professional translator. Translate the text accurately while preserving meaning, tone, "
                 "and formatting. Only return the translation, nothing else."
             ),
-            messages=[
-                {
-                    "role": "user", 
-                    "content": f"Translate this text from {source_lang} to {target_lang}:\n\n{text}"
-                }
-            ],
+            messages=[{"role": "user", "content": f"Translate this text from {source_lang} to {target_lang}:\n\n{text}"}],
         )
-        
+
         translation = response.content[0].text.strip()
         return translation
-        
+
     except Exception as e:
         logger.error(f"Translation error: {str(e)}")
         raise
 
+
 async def translate_texts_parallel(texts: list[str], target_lang: str = "en", source_lang: str = "ar") -> list[str]:
     """
     Translate multiple texts in parallel.
-    
+
     Args:
         texts: List of texts to translate
         target_lang: Target language code (e.g., "ar", "en")
         source_lang: Source language code (e.g., "ar", "en")
-            
+
     Returns:
         List of translations
     """
     if not texts:
         return []
-            
+
     # Create translation tasks for all texts
     tasks = [asyncio.to_thread(translate_text, text, target_lang, source_lang) for text in texts]
-        
+
     # Run all translations in parallel and return results
     return await asyncio.gather(*tasks)
+
+
+def format_multilingual_data(text_entries: Dict[str, str]) -> str:
+    """Convert a dictionary of language-text pairs to a JSON string.
+
+    This function is used by search tools to format multilingual content
+    in a consistent way. The format allows tools that return content in
+    multiple languages (like Quran and Hadith) to be properly handled,
+    and avoids duplicate translations.
+
+    Args:
+        text_entries: Dictionary mapping language codes to text
+            e.g., {"ar": "النص العربي", "en": "English text"}
+
+    Returns:
+        JSON string representing language-text pairs in the format:
+        [
+            {"lang": "ar", "text": "النص العربي"},
+            {"lang": "en", "text": "English translation"}
+        ]
+    """
+    result = []
+    for lang, text in text_entries.items():
+        if text:  # Only include non-empty text
+            result.append({"lang": lang, "text": text})
+    return json.dumps(result)
+
+
+def parse_multilingual_data(data: str) -> Dict[str, str]:
+    """Parse a JSON string representing multilingual content into a dictionary.
+
+    This is the reverse of format_multilingual_data.
+
+    Args:
+        data: JSON string in the format returned by format_multilingual_data
+
+    Returns:
+        Dictionary mapping language codes to text
+        e.g., {"ar": "النص العربي", "en": "English text"}
+
+    Raises:
+        json.JSONDecodeError: If the data is not valid JSON
+        ValueError: If the data is not in the expected format
+    """
+    try:
+        parsed = json.loads(data)
+        if not isinstance(parsed, list):
+            raise ValueError("Expected a JSON array")
+
+        result = {}
+        for item in parsed:
+            if not isinstance(item, dict) or "lang" not in item or "text" not in item:
+                raise ValueError("Expected items with 'lang' and 'text' fields")
+            result[item["lang"]] = item["text"]
+        return result
+
+    except json.JSONDecodeError:
+        raise
+    except Exception as e:
+        raise ValueError(f"Invalid multilingual data format: {str(e)}")

--- a/tests/integration/test_ansari_generic.py
+++ b/tests/integration/test_ansari_generic.py
@@ -11,156 +11,152 @@ from tests.integration.test_helpers import history_and_log_matches, IntegrationM
 # Set logging level for this module
 logger = get_logger(__name__)
 
+
 # Mock database implementation for testing reconstruction
 class MockDatabase:
     def __init__(self):
         self.stored_messages = []
-        
+
     def append_message(self, user_id, thread_id, role, content, tool_name=None, tool_details=None, ref_list=None):
         """Store message in mock database"""
         # Serialize complex structures like a real database would
         serialized_content = json.dumps(content) if isinstance(content, (dict, list)) else content
         serialized_tool_details = json.dumps(tool_details) if tool_details is not None else None
         serialized_ref_list = json.dumps(ref_list) if ref_list is not None else None
-        
-        self.stored_messages.append((
-            role,
-            serialized_content,
-            tool_name,
-            serialized_tool_details,
-            serialized_ref_list
-        ))
-        
+
+        self.stored_messages.append((role, serialized_content, tool_name, serialized_tool_details, serialized_ref_list))
+
     def get_stored_messages(self):
         """Return all stored messages"""
         return self.stored_messages
-        
+
     def convert_message_llm(self, msg):
         # Import the actual implementation from ansari_db.py
         from ansari.ansari_db import AnsariDB
+
         db = AnsariDB(Settings())
         return db.convert_message_llm(msg)
-        
+
     def convert_message(self, msg):
         """Convert a message from database format to API format.
-        
+
         Delegates to the real AnsariDB.convert_message method.
         """
         # Import the actual implementation from ansari_db.py
         from ansari.ansari_db import AnsariDB
+
         db = AnsariDB(Settings())
         return db.convert_message(msg)
 
 
 class AnsariTester:
     """Generic tester class for Ansari implementations.
-    
+
     This class provides methods to test different Ansari implementations with the same test cases.
     It can be used to ensure all implementations satisfy the common interface and behavior.
     """
-    
+
     def __init__(self, agent_class: Type[Ansari], settings: Settings = None):
         """Initialize the tester with the Ansari implementation class to test.
-        
+
         Args:
             agent_class: The Ansari implementation class to test
             settings: Optional settings object
         """
         self.agent_class = agent_class
         self.settings = settings or Settings()
-        
+
     def create_agent(self, message_logger=None):
         """Create an instance of the agent with the given logger."""
         return self.agent_class(settings=self.settings, message_logger=message_logger)
-    
+
     def test_simple_conversation(self):
         """Test a simple conversation with the agent."""
         logger.info(f"Starting simple conversation test for {self.agent_class.__name__}")
-        
+
         message_logger = IntegrationMessageLogger()
         message_logger.reset()  # Reset before the test
         agent = self.create_agent(message_logger)
-        
+
         # Test a simple conversation
         logger.debug("Starting simple conversation test")
-        responses =  agent.process_input("What sources do you use?")
+        responses = agent.process_input("What sources do you use?")
         logger.debug("Ended")
-        
+
         # Combine all responses
         full_response = "".join(responses)
-        
+
         # Verify we got a meaningful response
         assert len(full_response) > 50  # Response should be substantial
-        
+
         # Verify messages were logged
         assert len(message_logger.messages) >= 2  # Should have at least user input and response
-        
+
         # Verify message logger messages match agent history
         history_and_log_matches(agent, message_logger)
-        
+
         # Verify messages were logged with correct roles
         assert any(msg["role"] == "user" for msg in message_logger.messages)
         assert any(msg["role"] == "assistant" for msg in message_logger.messages)
-        
+
         return True
-    
+
     def test_conversation_with_references(self):
         """Test a conversation with references to religious texts."""
         logger.info(f"Starting conversation with references test for {self.agent_class.__name__}")
-        
+
         message_logger = IntegrationMessageLogger()
         message_logger.reset()  # Reset before the test
         agent = self.create_agent(message_logger)
-        
+
         # Test a query that should trigger reference lookups
         responses = []
         for response in agent.process_input("Are corals mentioned in the Quran?"):
             responses.append(response)
-        
+
         # Combine all responses
         full_response = "".join(responses)
-        
+
         # Verify we got a meaningful response
         assert len(full_response) > 100  # Response should be substantial
-        
+
         # Verify messages were logged with references
         assert len(message_logger.messages) >= 2
-        
+
         # Verify message logger messages match agent history
         history_and_log_matches(agent, message_logger)
 
-
         return True
-    
+
     def test_multi_turn_conversation(self):
         """Test a multi-turn conversation with the agent."""
         logger.info(f"Starting multi-turn conversation test for {self.agent_class.__name__}")
-        
+
         message_logger = IntegrationMessageLogger()
         message_logger.reset()  # Reset before the test
         agent = self.create_agent(message_logger)
-        
+
         # First turn
         responses1 = []
         for response in agent.process_input("What is the concept of Tawakkul in Islam?"):
             responses1.append(response)
         full_response1 = "".join(responses1)
         assert len(full_response1) > 50
-        
+
         # Second turn - follow-up question
         responses2 = []
         for response in agent.process_input("How can one practically apply this concept in daily life?"):
             responses2.append(response)
         full_response2 = "".join(responses2)
         assert len(full_response2) > 50
-        
+
         # Verify conversation flow
         messages = message_logger.messages
         assert len(messages) >= 4  # Should have at least 4 messages (2 user, 2 assistant)
-        
+
         # Verify message logger messages match agent history
         history_and_log_matches(agent, message_logger)
-        
+
         # Verify context retention (look for "Tawakkul" in any message content)
         has_context = False
         for msg in messages:
@@ -169,57 +165,56 @@ class AnsariTester:
             if "Tawakkul" in content_str:
                 has_context = True
                 break
-                
+
         assert has_context, "Context was not retained between conversation turns"
-        
+
         return True
-    
+
     def test_message_conversion(self):
         """Test message conversion functions for converting database messages to API/LLM format."""
         logger.info(f"Starting message conversion test for {self.agent_class.__name__}")
-        
+
         mock_db = MockDatabase()
-        
+
         # Process a message to generate some conversation data
         message_logger = IntegrationMessageLogger()
         message_logger.reset()  # Reset before the test
         agent = self.create_agent(message_logger)
-        
+
         # Generate some message data
         for response in agent.process_input("What are the five pillars of Islam?"):
             pass
-            
+
         # Store messages in mock database
         for i, msg in enumerate(message_logger.messages):
             mock_db.append_message(
-                user_id=1, 
-                thread_id=1, 
-                role=msg["role"], 
+                user_id=1,
+                thread_id=1,
+                role=msg["role"],
                 content=msg["content"],
                 tool_name=msg["tool_name"],
                 tool_details=msg["tool_details"],
-                ref_list=msg["ref_list"]
+                ref_list=msg["ref_list"],
             )
-            
+
         # Test convert_message (DB format to API format)
         for i, msg in enumerate(mock_db.get_stored_messages()):
             api_msg = mock_db.convert_message(msg)
             assert "role" in api_msg, f"API message {i} missing role"
             assert "content" in api_msg, f"API message {i} missing content"
             assert api_msg["role"] == msg[0], f"API message {i} has incorrect role"
-            
+
         # Test convert_message_llm (DB format to LLM format)
         for i, msg in enumerate(mock_db.get_stored_messages()):
             llm_msgs = mock_db.convert_message_llm(msg)
             assert len(llm_msgs) >= 1, "LLM conversion must return at least one message"
-            
+
             for llm_msg in llm_msgs:
                 assert "role" in llm_msg, f"LLM message {i} missing role"
                 assert "content" in llm_msg, f"LLM message {i} missing content"
                 assert llm_msg["role"] == msg[0], f"LLM message {i} has incorrect role"
-                
+
         return True
-    
 
     def run_all_tests(self) -> List[bool]:
         """Run all tests and return the results."""
@@ -227,9 +222,9 @@ class AnsariTester:
             self.test_simple_conversation,
             self.test_conversation_with_references,
             self.test_multi_turn_conversation,
-            self.test_message_conversion
+            self.test_message_conversion,
         ]
-        
+
         results = []
         for test_method in test_methods:
             try:
@@ -239,21 +234,24 @@ class AnsariTester:
             except Exception as e:
                 logger.error(f"Test {test_method.__name__} failed for {self.agent_class.__name__}: {str(e)}")
                 results.append(False)
-                
+
         return results
 
 
 # Pytest fixtures and tests
 
+
 @pytest.fixture
 def settings():
     return Settings()
+
 
 @pytest.fixture(autouse=True)
 def setup_message_logger():
     message_logger = IntegrationMessageLogger()
     yield message_logger
     message_logger.reset()  # Clean up after each test
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize("agent_class", [Ansari, AnsariClaude])
@@ -262,12 +260,14 @@ def test_simple_conversation_all_agents(agent_class, settings):
     tester = AnsariTester(agent_class, settings)
     assert tester.test_simple_conversation()
 
+
 @pytest.mark.integration
 @pytest.mark.parametrize("agent_class", [Ansari, AnsariClaude])
 def test_conversation_with_references_all_agents(agent_class, settings):
     """Run the conversation with references test on all agent implementations."""
     tester = AnsariTester(agent_class, settings)
     assert tester.test_conversation_with_references()
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize("agent_class", [Ansari, AnsariClaude])
@@ -276,6 +276,7 @@ def test_multi_turn_conversation_all_agents(agent_class, settings):
     tester = AnsariTester(agent_class, settings)
     assert tester.test_multi_turn_conversation()
 
+
 @pytest.mark.integration
 @pytest.mark.parametrize("agent_class", [Ansari, AnsariClaude])
 def test_message_conversion_all_agents(agent_class, settings):
@@ -283,10 +284,11 @@ def test_message_conversion_all_agents(agent_class, settings):
     tester = AnsariTester(agent_class, settings)
     assert tester.test_message_conversion()
 
+
 # Helper function to run tests directly
 def run_tests_for_implementation(agent_class: Type[Ansari]):
     """Run all tests for a specific implementation."""
     settings = Settings()
     tester = AnsariTester(agent_class, settings)
     results = tester.run_all_tests()
-    return all(results) 
+    return all(results)

--- a/tests/integration/test_ansari_integration.py
+++ b/tests/integration/test_ansari_integration.py
@@ -9,23 +9,28 @@ from tests.integration.test_ansari_generic import AnsariTester, IntegrationMessa
 
 logger = get_logger(__name__)
 
+
 @pytest.fixture
 def settings():
     settings = Settings()
     return settings
 
+
 @pytest.fixture
 def message_logger():
     return IntegrationMessageLogger()
+
 
 @pytest.fixture
 def mock_db():
     return MockDatabase()
 
+
 @pytest.fixture
 def ansari_tester(settings):
     """Create an AnsariTester configured for base Ansari"""
     return AnsariTester(Ansari, settings)
+
 
 @pytest.mark.integration
 def test_simple_conversation(ansari_tester):
@@ -33,11 +38,13 @@ def test_simple_conversation(ansari_tester):
     logger.info("Starting simple conversation integration test for Ansari")
     assert ansari_tester.test_simple_conversation()
 
+
 @pytest.mark.integration
 def test_conversation_with_references(ansari_tester):
     """Integration test for a conversation that should include Quran/Hadith references"""
     logger.info("Starting conversation with references integration test for Ansari")
     assert ansari_tester.test_conversation_with_references()
+
 
 @pytest.mark.integration
 def test_multi_turn_conversation(ansari_tester):
@@ -48,86 +55,87 @@ def test_multi_turn_conversation(ansari_tester):
 
 class TestMessageReconstruction:
     """Tests that focus specifically on message reconstruction between agent and database"""
-    
+
     @pytest.mark.integration
     def test_full_reconstruction_cycle(self, settings, mock_db):
         """Test the full cycle: Message creation → Database storage → Retrieval → Reconstruction"""
         logger.info("Testing full message reconstruction cycle")
-        
+
         # Create logger that uses our mock database
         message_logger = MessageLogger(mock_db, 1, 1)
-        
+
         # Create the agent
         agent = Ansari(settings=settings, message_logger=message_logger)
-        
+
         # Process a query likely to use tools
         for _ in agent.process_input("What does Surah Al-Baqarah say about fasting?"):
             pass
-            
+
         # Verify we have messages in the agent's history
         assert len(agent.message_history) > 0, "No messages in agent history"
-        
+
         # Get the stored messages from the mock DB
         stored_messages = mock_db.get_stored_messages()
         assert len(stored_messages) > 0, "No messages stored in mock database"
-        
+
         # Reconstruct messages using the convert_message_llm method
         reconstructed_messages = []
         for msg in stored_messages:
             reconstructed_msgs = mock_db.convert_message_llm(msg)
             reconstructed_messages.extend(reconstructed_msgs)
-            
+
         # Verify reconstructed messages match agent's history in structure
         assert len(reconstructed_messages) > 0, "No messages were reconstructed"
-        
+
         # Check each message for structural validity
         for msg in reconstructed_messages:
             assert "role" in msg, "Reconstructed message missing role"
             assert "content" in msg, "Reconstructed message missing content"
-    
+
     @pytest.mark.integration
     def test_edge_cases(self, settings):
         """Test edge cases for message reconstruction"""
         logger.info("Testing message reconstruction edge cases")
-        
+
         mock_db = MockDatabase()
-        
+
         # Test Case 1: Plain text message
         plain_text_msg = ("assistant", "Simple text response", None, None, None)
         reconstructed = mock_db.convert_message_llm(plain_text_msg)
         assert len(reconstructed) == 1, "Should have one reconstructed message"
         assert reconstructed[0]["role"] == "assistant", "Role should be preserved"
         assert reconstructed[0]["content"] == "Simple text response", "Content should be preserved as is"
-        
+
         # Test Case 2: Tool call message
         tool_msg = (
-            "assistant", 
-            "Let me search for that", 
-            "search_quran", 
-            json.dumps({"id": "123", "input": {"query": "test"}}), 
-            None
+            "assistant",
+            "Let me search for that",
+            "search_quran",
+            json.dumps({"id": "123", "input": {"query": "test"}}),
+            None,
         )
         reconstructed = mock_db.convert_message_llm(tool_msg)
         assert len(reconstructed) == 1, "Should have one reconstructed message"
         assert reconstructed[0]["role"] == "assistant", "Role should be preserved"
         assert isinstance(reconstructed[0]["content"], str), "Content should be a string for base Ansari"
-        
+
         # Test Case 3: Message with tool results
         tool_result_msg = (
             "tool",
             "Tool result text",
             "search_quran",
             json.dumps({"id": "123", "internal_message": "Internal message", "tool_message": "Tool message"}),
-            None
+            None,
         )
         reconstructed = mock_db.convert_message_llm(tool_result_msg)
         assert len(reconstructed) == 1, "Should have one reconstructed message"
         assert reconstructed[0]["role"] == "tool", "Role should be preserved"
         assert isinstance(reconstructed[0]["content"], str), "Content should be a string"
 
+
 @pytest.mark.integration
 def test_run_all_ansari_tests(settings):
     """Run all tests for base Ansari using the generic tester"""
     tester = AnsariTester(Ansari, settings)
     results = tester.run_all_tests()
-    assert all(results), "All tests should pass for base Ansari" 
+    assert all(results), "All tests should pass for base Ansari"

--- a/tests/integration/test_claude_integration.py
+++ b/tests/integration/test_claude_integration.py
@@ -11,25 +11,30 @@ logger = get_logger(__name__)
 # Import the generic tester class to reuse test logic
 from tests.integration.test_ansari_generic import IntegrationMessageLogger, MockDatabase
 
+
 @pytest.fixture
 def settings():
     settings = Settings()
     return settings
 
+
 @pytest.fixture
 def message_logger():
     return IntegrationMessageLogger()
+
 
 @pytest.fixture
 def mock_db():
     return MockDatabase()
 
+
 @pytest.fixture
 def claude_tester(settings):
     """Create an AnsariTester configured for AnsariClaude"""
-    # Just testing basic stuff, let's make it as fast as possible. 
+    # Just testing basic stuff, let's make it as fast as possible.
     settings.MODEL = "claude-3-5-haiku-latest"
     return AnsariTester(AnsariClaude, settings)
+
 
 @pytest.mark.integration
 def test_simple_conversation(claude_tester):
@@ -37,11 +42,13 @@ def test_simple_conversation(claude_tester):
     logger.info("Starting simple conversation integration test for AnsariClaude")
     assert claude_tester.test_simple_conversation()
 
+
 @pytest.mark.integration
 def test_conversation_with_references(claude_tester):
     """Integration test for a conversation that should include Quran/Hadith references"""
     logger.info("Starting conversation with references integration test for AnsariClaude")
     assert claude_tester.test_conversation_with_references()
+
 
 @pytest.mark.integration
 def test_multi_turn_conversation(claude_tester):
@@ -49,118 +56,119 @@ def test_multi_turn_conversation(claude_tester):
     logger.info("Starting multi-turn conversation integration test for AnsariClaude")
     assert claude_tester.test_multi_turn_conversation()
 
+
 # The following tests are specific to AnsariClaude implementation and test Claude-specific features
+
 
 class TestMessageReconstruction:
     """Tests that focus specifically on message reconstruction between agent and database"""
-    
+
     @pytest.mark.integration
     def test_full_reconstruction_cycle(self, settings, mock_db):
         """Test the full cycle: Message creation → Database storage → Retrieval → Reconstruction"""
         logger.info("Testing full message reconstruction cycle")
-        
+
         # Create logger that uses our mock database
         message_logger = MessageLogger(mock_db, 1, 1)
-        
+
         # Create the agent
         agent = AnsariClaude(settings=settings, message_logger=message_logger)
-        
+
         # Process a query likely to use tools
         for _ in agent.process_input("What does Surah Al-Baqarah say about fasting?"):
             pass
-            
+
         # Verify we have messages in the agent's history
         assert len(agent.message_history) > 0, "No messages in agent history"
-        
+
         # Get the stored messages from the mock DB
         stored_messages = mock_db.get_stored_messages()
         assert len(stored_messages) > 0, "No messages stored in mock database"
-        
+
         # Reconstruct messages using the convert_message_llm method
         reconstructed_messages = []
         for msg in stored_messages:
             reconstructed_msgs = mock_db.convert_message_llm(msg)
             reconstructed_messages.extend(reconstructed_msgs)
-            
+
         # Verify reconstructed messages match agent's history in structure
         assert len(reconstructed_messages) > 0, "No messages were reconstructed"
-        
+
         # Check each message for structural validity
         for msg in reconstructed_messages:
             assert "role" in msg, "Reconstructed message missing role"
             assert "content" in msg, "Reconstructed message missing content"
-            
+
             # Assistant messages should have structured content
             if msg["role"] == "assistant":
                 assert isinstance(msg["content"], list), "Assistant message content should be a list"
                 for block in msg["content"]:
                     assert isinstance(block, dict), "Assistant message content block should be a dict"
                     assert "type" in block, "Assistant message content block missing type"
-    
+
     @pytest.mark.integration
     def test_claude_specific_message_structure(self, settings):
         """Test Claude-specific message structure validation"""
         logger.info("Testing Claude-specific message structure")
-        
+
         agent = AnsariClaude(settings=settings)
-        
+
         # Validate message structure for Claude
-        valid_message = {
-            "role": "assistant",
-            "content": [{"type": "text", "text": "Test response"}]
-        }
+        valid_message = {"role": "assistant", "content": [{"type": "text", "text": "Test response"}]}
         assert agent.validate_message(valid_message), "Valid Claude message should pass validation"
-        
+
         # Test invalid message
         invalid_message = {
             "role": "assistant",
-            "content": "Plain text content"  # Claude requires list content for assistant
+            "content": "Plain text content",  # Claude requires list content for assistant
         }
         assert not agent.validate_message(invalid_message), "Invalid Claude message should fail validation"
-    
+
     @pytest.mark.integration
     def test_edge_cases(self, settings):
         """Test edge cases for message reconstruction"""
         logger.info("Testing message reconstruction edge cases")
-        
+
         mock_db = MockDatabase()
-        
+
         # Test Case 1: Empty content
         empty_content_msg = ("assistant", json.dumps([{"type": "text", "text": ""}]), None, None, None)
         reconstructed = mock_db.convert_message_llm(empty_content_msg)
         assert len(reconstructed) == 1, "Should have one reconstructed message"
         assert reconstructed[0]["role"] == "assistant", "Role should be preserved"
         assert isinstance(reconstructed[0]["content"], list), "Content should be a list"
-        
+
         # Test Case 2: Only tool use with no text content
         tool_only_msg = (
-            "assistant", 
+            "assistant",
             "[]",  # Empty content array
-            "search_hadith", 
-            json.dumps({"id": "123", "input": {"query": "test"}}), 
-            None
+            "search_hadith",
+            json.dumps({"id": "123", "input": {"query": "test"}}),
+            None,
         )
         reconstructed = mock_db.convert_message_llm(tool_only_msg)
         assert len(reconstructed) == 1, "Should have one reconstructed message"
         assert reconstructed[0]["role"] == "assistant", "Role should be preserved"
         assert isinstance(reconstructed[0]["content"], list), "Content should be a list"
         assert any(block.get("type") == "tool_use" for block in reconstructed[0]["content"]), "Should have tool use block"
-        
+
         # Test Case 3: Message with tool results
         tool_result_msg = (
             "user",
             json.dumps([{"type": "tool_result", "tool_use_id": "123", "content": "Test result"}]),
             "search_hadith",
             json.dumps({"id": "123"}),
-            json.dumps([{"type": "document", "document": {"title": "Test Doc", "content": "Test content"}}])
+            json.dumps([{"type": "document", "document": {"title": "Test Doc", "content": "Test content"}}]),
         )
         reconstructed = mock_db.convert_message_llm(tool_result_msg)
         assert len(reconstructed) == 1, "Should have one reconstructed message"
         assert reconstructed[0]["role"] == "user", "Role should be preserved"
         assert isinstance(reconstructed[0]["content"], list), "Content should be a list"
-        assert any(block.get("type") == "tool_result" for block in reconstructed[0]["content"]), \
+        assert any(block.get("type") == "tool_result" for block in reconstructed[0]["content"]), (
             "Should have tool result block"
+        )
         assert any(block.get("type") == "document" for block in reconstructed[0]["content"]), "Should have document block"
+
 
 @pytest.mark.integration
 def test_run_all_claude_tests(settings):

--- a/tests/integration/test_helpers.py
+++ b/tests/integration/test_helpers.py
@@ -1,8 +1,10 @@
 """Helper functions for integration tests."""
+
 from ansari.ansari_logger import get_logger
 import json
 
 logger = get_logger(__name__)
+
 
 class IntegrationMessageLogger:
     def __init__(self):
@@ -11,38 +13,35 @@ class IntegrationMessageLogger:
     def reset(self):
         """Reset the message log."""
         self.messages = []
-        
+
     def log(self, role, content, tool_name=None, tool_details=None, ref_list=None):
-        self.messages.append({
-            "role": role,
-            "content": content,
-            "tool_name": tool_name,
-            "tool_details": tool_details,
-            "ref_list": ref_list
-        })
+        self.messages.append(
+            {"role": role, "content": content, "tool_name": tool_name, "tool_details": tool_details, "ref_list": ref_list}
+        )
+
 
 def history_and_log_matches(agent, message_logger):
     """Verify that the message history in the agent matches the messages in the logger.
-    
+
     Args:
         agent: The Ansari agent instance (can be any subclass)
         message_logger: The message logger instance
-    
+
     Raises:
         AssertionError: If the messages don't match
     """
     # Determine agent type
     agent_class_name = agent.__class__.__name__
-    
+
     # Convert message history to comparable format
     history_messages = []
     for msg in agent.message_history:
         # Skip system messages as they are not logged
         if msg["role"] not in ["user", "assistant", "tool"]:
             continue
-            
+
         logger.debug(f"Processing message from history: {msg}")
-        
+
         # For simple string content (mostly user messages)
         if isinstance(msg["content"], str):
             history_msg = {
@@ -50,18 +49,18 @@ def history_and_log_matches(agent, message_logger):
                 "content": msg["content"],
                 "tool_name": None,
                 "tool_details": None,
-                "ref_list": None
+                "ref_list": None,
             }
             history_messages.append(history_msg)
             continue
-            
+
         # Handle Claude's message format where content is a list of blocks
         if isinstance(msg["content"], list):
             content = msg["content"]  # Keep the original content structure
             tool_name = None
             tool_details = None
             ref_list = None
-            
+
             # Extract tool information if present (specific to AnsariClaude format)
             if agent_class_name == "AnsariClaude":
                 for block in msg["content"]:
@@ -73,13 +72,13 @@ def history_and_log_matches(agent, message_logger):
                         ref_blocks = [b for b in msg["content"] if b.get("type") == "document"]
                         if ref_blocks:
                             ref_list = ref_blocks
-            
+
             history_msg = {
                 "role": msg["role"],
                 "content": content,
                 "tool_name": tool_name,
                 "tool_details": tool_details,
-                "ref_list": ref_list
+                "ref_list": ref_list,
             }
         else:
             # Handle plain text messages
@@ -88,26 +87,26 @@ def history_and_log_matches(agent, message_logger):
                 "content": msg["content"],
                 "tool_name": None,
                 "tool_details": None,
-                "ref_list": None
+                "ref_list": None,
             }
-            
+
         history_messages.append(history_msg)
-    
+
     # Print detailed message information for debugging
     logger.info(f"=== History Messages ({len(history_messages)}) ===")
     for i, msg in enumerate(history_messages):
         logger.info(f"History Message {i}:")
         logger.info(f"  Role: {msg['role']}")
-        if msg['role'] == 'tool':
+        if msg["role"] == "tool":
             logger.info(f"  Tool Call ID: {msg.get('tool_call_id', 'None')}")
-        
+
     logger.info(f"=== Logger Messages ({len(message_logger.messages)}) ===")
     for i, msg in enumerate(message_logger.messages):
         logger.info(f"Logger Message {i}:")
         logger.info(f"  Role: {msg['role']}")
-        if msg['role'] == 'assistant':
+        if msg["role"] == "assistant":
             logger.info(f"  Tool Details: {msg.get('tool_details', 'None')}")
-    
+
     # For Ansari class, we know it may have more messages in history than in logger
     # This is because some tool results may be added to message history but not logged
     # What's important is that the key messages (user and final assistant responses) are present
@@ -115,60 +114,65 @@ def history_and_log_matches(agent, message_logger):
         # Check that we have at least one user message and one assistant message at the end
         assert len(history_messages) >= 2, "History must have at least 2 messages"
         assert len(message_logger.messages) >= 2, "Logger must have at least 2 messages"
-        
+
         # Check that the first message is a user message
-        assert history_messages[0]["role"] == "user" and message_logger.messages[0]["role"] == "user", \
+        assert history_messages[0]["role"] == "user" and message_logger.messages[0]["role"] == "user", (
             "First message must be from user"
-            
+        )
+
         # Check that the last message in both is from assistant (final response)
-        assert history_messages[-1]["role"] == "assistant" and message_logger.messages[-1]["role"] == "assistant", \
+        assert history_messages[-1]["role"] == "assistant" and message_logger.messages[-1]["role"] == "assistant", (
             "Last message must be from assistant"
+        )
     else:
         # For other agent types (e.g., AnsariClaude), we expect exact match
-        assert len(history_messages) == len(message_logger.messages), \
+        assert len(history_messages) == len(message_logger.messages), (
             f"Message count mismatch between history ({len(history_messages)}) and logger ({len(message_logger.messages)})"
-    
+        )
+
     # For Ansari class, we only want to compare key messages like user queries and final responses
     if agent_class_name == "Ansari":
         # Find user messages and their responses in both histories
         key_messages = []
-        
+
         # First message is always user query
         key_messages.append((0, 0))  # (history_idx, logger_idx)
-        
+
         # Last message is always assistant's final response
         key_messages.append((len(history_messages) - 1, len(message_logger.messages) - 1))
-        
+
         # For each key message pair, check basic message properties
-        for (hist_idx, log_idx) in key_messages:
+        for hist_idx, log_idx in key_messages:
             hist_msg = history_messages[hist_idx]
             log_msg = message_logger.messages[log_idx]
-            
+
             # Check that roles match
-            assert hist_msg["role"] == log_msg["role"], \
-                f"Message role mismatch: {hist_msg['role']} vs {log_msg['role']}"
-                
+            assert hist_msg["role"] == log_msg["role"], f"Message role mismatch: {hist_msg['role']} vs {log_msg['role']}"
+
             # For content of simple text messages, verify it matches
             if hist_msg["role"] == "user" and isinstance(hist_msg["content"], str) and isinstance(log_msg["content"], str):
-                assert hist_msg["content"] == log_msg["content"], \
+                assert hist_msg["content"] == log_msg["content"], (
                     f"User message content mismatch: {hist_msg['content']} vs {log_msg['content']}"
+                )
     else:
         # For other agent types (e.g., AnsariClaude), we do a full comparison
         for i, (hist_msg, log_msg) in enumerate(zip(history_messages, message_logger.messages)):
             # Check that roles match
             assert hist_msg["role"] == log_msg["role"], f"Message {i} role mismatch: {hist_msg['role']} vs {log_msg['role']}"
-            
+
             # For content, we need to handle various formats based on the agent type
             if isinstance(hist_msg["content"], str) and isinstance(log_msg["content"], str):
-                assert hist_msg["content"] == log_msg["content"], \
+                assert hist_msg["content"] == log_msg["content"], (
                     f"Message {i} content mismatch: {hist_msg['content']} vs {log_msg['content']}"
+                )
             elif isinstance(hist_msg["content"], list) and isinstance(log_msg["content"], list):
                 # For list content, convert to JSON strings for deep comparison
                 hist_json = json.dumps(hist_msg["content"], sort_keys=True)
                 log_json = json.dumps(log_msg["content"], sort_keys=True)
-                assert hist_json == log_json, f"Message {i} content structure mismatch:\nHistory: {hist_json}\nLogger: {log_json}"
-            elif (isinstance(hist_msg["content"], str) and 
-                  isinstance(log_msg["content"], (list, dict))):
+                assert hist_json == log_json, (
+                    f"Message {i} content structure mismatch:\nHistory: {hist_json}\nLogger: {log_json}"
+                )
+            elif isinstance(hist_msg["content"], str) and isinstance(log_msg["content"], (list, dict)):
                 # For Ansari base class, the message_logger might store structured content for some messages
                 # Convert structured content to string for comparison
                 log_content_str = json.dumps(log_msg["content"])
@@ -176,14 +180,16 @@ def history_and_log_matches(agent, message_logger):
                 assert hist_msg["content"] in log_content_str, f"Message {i} content not found in structured content"
             else:
                 # If types don't match and it's not a known conversion case
-                logger.warning(f"Content type mismatch for message {i}: {type(hist_msg['content'])} vs {type(log_msg['content'])}")
+                logger.warning(
+                    f"Content type mismatch for message {i}: {type(hist_msg['content'])} vs {type(log_msg['content'])}"
+                )
                 logger.warning("This might be normal for some agent implementations.")
                 # We don't assert here as different implementations may store content differently
-            
+
             # Compare other fields more loosely
             if hist_msg["tool_name"] != log_msg["tool_name"]:
                 logger.warning(f"Tool name mismatch for message {i}: {hist_msg['tool_name']} vs {log_msg['tool_name']}")
-            
+
             # Compare tool details if present
             if hist_msg["tool_details"] is not None and log_msg["tool_details"] is not None:
                 # For different implementations, tool details might be structured differently
@@ -191,7 +197,7 @@ def history_and_log_matches(agent, message_logger):
                 hist_has_details = hist_msg["tool_details"] is not None
                 log_has_details = log_msg["tool_details"] is not None
                 assert hist_has_details == log_has_details, f"Tool details presence mismatch for message {i}"
-            
+
             # Compare reference list if present
             if hist_msg["ref_list"] is not None and log_msg["ref_list"] is not None:
                 # Just check that reference lists are present, not that they match exactly

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,1 +1,1 @@
-"""Unit tests for the Ansari project.""" 
+"""Unit tests for the Ansari project."""

--- a/tests/unit/test_ansari_claude_message_sequence.py
+++ b/tests/unit/test_ansari_claude_message_sequence.py
@@ -1,11 +1,10 @@
-import json
 import uuid
 import sys
 import os
 from unittest.mock import MagicMock, patch
 
 # Add the src directory to the path so we can import the modules
-src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../'))
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
 sys.path.insert(0, src_path)
 
 from ansari.agents.ansari_claude import AnsariClaude
@@ -16,7 +15,7 @@ from ansari.ansari_db import MessageLogger
 def test_message_sequence_with_tool_use():
     """
     Test a complete message sequence with tool use and tool result.
-    
+
     This tests the following sequence:
     1. Assistant message with tool_use
     2. User message with tool_result
@@ -28,26 +27,26 @@ def test_message_sequence_with_tool_use():
     settings.ANTHROPIC_MODEL = "claude-3-opus-20240229"
     settings.diskcache_dir = "/tmp/diskcache"
     settings.MAX_FAILURES = 3
-    
+
     # Create a mock message logger
     message_logger = MagicMock(spec=MessageLogger)
-    
+
     # Create a mocked AnsariClaude instance with initial tools setup
-    with patch('anthropic.Anthropic'), patch.object(AnsariClaude, '__init__', return_value=None):
+    with patch("anthropic.Anthropic"), patch.object(AnsariClaude, "__init__", return_value=None):
         claude = AnsariClaude.__new__(AnsariClaude)
         claude.settings = settings
         claude.message_logger = message_logger
-        
+
         # Set needed attributes that would normally be set in __init__
         claude.tools = []
         claude.tool_name_to_instance = {}
         claude.citations = []
         claude.message_history = []
         claude.client = MagicMock()
-        
+
         # Create a unique tool ID
         tool_id = str(uuid.uuid4())
-        
+
         # Setup a message sequence with tool use and tool result
         claude.message_history = [
             # 1. Assistant message with tool_use
@@ -55,97 +54,77 @@ def test_message_sequence_with_tool_use():
                 "role": "assistant",
                 "content": [
                     {"type": "text", "text": "Let me search for that information."},
-                    {
-                        "type": "tool_use",
-                        "id": tool_id,
-                        "name": "search_quran",
-                        "input": {"query": "mercy in quran"}
-                    }
-                ]
+                    {"type": "tool_use", "id": tool_id, "name": "search_quran", "input": {"query": "mercy in quran"}},
+                ],
             },
-            
             # 2. User message with tool_result
             {
                 "role": "user",
-                "content": [
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": tool_id,
-                        "content": "Found 114 verses mentioning mercy."
-                    }
-                ]
+                "content": [{"type": "tool_result", "tool_use_id": tool_id, "content": "Found 114 verses mentioning mercy."}],
             },
-            
             # 3. Assistant explanation
             {
                 "role": "assistant",
-                "content": [
-                    {"type": "text", "text": "I found that the concept of mercy appears frequently in the Quran."}
-                ]
+                "content": [{"type": "text", "text": "I found that the concept of mercy appears frequently in the Quran."}],
             },
-            
             # 4. Simple user message
-            {
-                "role": "user",
-                "content": "Can you tell me more about that?"
-            }
+            {"role": "user", "content": "Can you tell me more about that?"},
         ]
-        
+
         # Process the message history
         # Mock the API response to avoid actual API calls
         mock_response = MagicMock()
         claude.client.messages.create.return_value = mock_response
         claude.process_one_round = MagicMock(return_value=[])
-        
+
         # Run the message processing
         # Make a copy of the history for comparison
         original_history = [msg.copy() for msg in claude.message_history]
-        
+
         # Process the message history
         list(claude.process_message_history(use_tool=False, stream=False))
-        
+
         # Check that the message history structure was preserved
         processed_history = claude.message_history
-        
+
         # Compare the content of each message to ensure the structure is maintained
         for i, (orig, processed) in enumerate(zip(original_history, processed_history)):
             # Check that roles match
             assert orig["role"] == processed["role"], f"Role mismatch at message {i}"
-            
+
             # For assistant messages, ensure content remains a list of blocks
             if orig["role"] == "assistant":
                 assert isinstance(processed["content"], list), f"Assistant content should be a list at message {i}"
-                
+
                 # Check for tool_use blocks
                 orig_tool_blocks = [b for b in orig["content"] if b.get("type") == "tool_use"]
                 processed_tool_blocks = [b for b in processed["content"] if b.get("type") == "tool_use"]
-                
-                assert len(orig_tool_blocks) == len(processed_tool_blocks), \
-                    f"Tool use blocks count mismatch at message {i}"
-                
+
+                assert len(orig_tool_blocks) == len(processed_tool_blocks), f"Tool use blocks count mismatch at message {i}"
+
                 # If there are tool blocks, check that IDs are preserved
                 if orig_tool_blocks:
-                    assert orig_tool_blocks[0]["id"] == processed_tool_blocks[0]["id"], \
-                        f"Tool use ID mismatch at message {i}"
-            
+                    assert orig_tool_blocks[0]["id"] == processed_tool_blocks[0]["id"], f"Tool use ID mismatch at message {i}"
+
             # For user messages with tool_result, ensure structure is maintained
             if orig["role"] == "user" and isinstance(orig["content"], list):
                 # Check that content is still a list
-                assert isinstance(processed["content"], list), \
-                    f"User tool_result content should remain a list at message {i}"
-                
+                assert isinstance(processed["content"], list), f"User tool_result content should remain a list at message {i}"
+
                 # Check for tool_result blocks
                 orig_result_blocks = [b for b in orig["content"] if b.get("type") == "tool_result"]
                 processed_result_blocks = [b for b in processed["content"] if b.get("type") == "tool_result"]
-                
-                assert len(orig_result_blocks) == len(processed_result_blocks), \
+
+                assert len(orig_result_blocks) == len(processed_result_blocks), (
                     f"Tool result blocks count mismatch at message {i}"
-                
+                )
+
                 # If there are result blocks, check that IDs are preserved
                 if orig_result_blocks:
-                    assert orig_result_blocks[0]["tool_use_id"] == processed_result_blocks[0]["tool_use_id"], \
+                    assert orig_result_blocks[0]["tool_use_id"] == processed_result_blocks[0]["tool_use_id"], (
                         f"Tool result ID mismatch at message {i}"
-        
+                    )
+
         print("All assertions passed - message sequence with tool use/result is correctly processed!")
 
 

--- a/tests/unit/test_ansari_claude_tool_sequence.py
+++ b/tests/unit/test_ansari_claude_tool_sequence.py
@@ -1,27 +1,27 @@
-import json
 import uuid
 import sys
 import os
 
 # Add the src directory to the path so we can import the modules
-src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../'))
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
 sys.path.insert(0, src_path)
 
 from unittest.mock import MagicMock, patch
 from ansari.agents.ansari_claude import AnsariClaude
 from ansari.config import Settings
 
+
 def test_process_message_history_with_tools():
     """Test that message processing correctly handles tool_use and tool_result relationships."""
-    
+
     # Create mock settings
     settings = MagicMock(spec=Settings)
     settings.ANTHROPIC_MODEL = "claude-3-opus-20240229"
-    
+
     # Create a unique tool ID for testing
     tool_id = str(uuid.uuid4())
     invalid_tool_id = str(uuid.uuid4())  # This won't match any tool_use block
-    
+
     # Create a test message history with tool use and tool result
     test_history = [
         # Message 1: Assistant with tool_use
@@ -29,99 +29,75 @@ def test_process_message_history_with_tools():
             "role": "assistant",
             "content": [
                 {"type": "text", "text": "Let me search for that information."},
-                {
-                    "type": "tool_use",
-                    "id": tool_id,
-                    "name": "search_quran",
-                    "input": {"query": "mercy in quran"}
-                }
-            ]
+                {"type": "tool_use", "id": tool_id, "name": "search_quran", "input": {"query": "mercy in quran"}},
+            ],
         },
-        
         # Message 2: User with tool_result (valid tool_use_id)
         {
             "role": "user",
-            "content": [
-                {
-                    "type": "tool_result",
-                    "tool_use_id": tool_id,
-                    "content": "Found 114 verses mentioning mercy."
-                }
-            ]
+            "content": [{"type": "tool_result", "tool_use_id": tool_id, "content": "Found 114 verses mentioning mercy."}],
         },
-        
         # Message 3: User with tool_result (invalid tool_use_id)
         {
-            "role": "user", 
-            "content": [
-                {
-                    "type": "tool_result",
-                    "tool_use_id": invalid_tool_id,
-                    "content": "This should be filtered out"
-                }
-            ]
-        },
-        
-        # Message 4: User with simple text
-        {
             "role": "user",
-            "content": "Tell me more about mercy in the Quran."
-        }
+            "content": [{"type": "tool_result", "tool_use_id": invalid_tool_id, "content": "This should be filtered out"}],
+        },
+        # Message 4: User with simple text
+        {"role": "user", "content": "Tell me more about mercy in the Quran."},
     ]
-    
+
     # Mock the necessary parts of AnsariClaude
-    with patch.object(AnsariClaude, '__init__', return_value=None), \
-         patch.object(AnsariClaude, 'process_one_round', return_value=[]):
-        
+    with (
+        patch.object(AnsariClaude, "__init__", return_value=None),
+        patch.object(AnsariClaude, "process_one_round", return_value=[]),
+    ):
         claude = AnsariClaude.__new__(AnsariClaude)
         claude.settings = settings
         claude.message_history = test_history.copy()
         claude.message_logger = None
         claude.client = MagicMock()
-        
+
         # Add a final assistant response to avoid infinite loop
         def add_assistant_response(*args, **kwargs):
             if len(claude.message_history) > 0 and claude.message_history[-1]["role"] == "user":
-                claude.message_history.append({
-                    "role": "assistant",
-                    "content": [{"type": "text", "text": "Test response"}]
-                })
+                claude.message_history.append({"role": "assistant", "content": [{"type": "text", "text": "Test response"}]})
             return []
-        
+
         claude.process_one_round = MagicMock(side_effect=add_assistant_response)
-        
+
         # Run the message processing
         list(claude.process_message_history(use_tool=False, stream=False))
-        
+
         # Verify the results
         processed_history = claude.message_history
-        
+
         # Message 1 (assistant with tool_use) should keep its structure
         assert processed_history[0]["role"] == "assistant"
         assert len(processed_history[0]["content"]) == 2
         assert processed_history[0]["content"][0]["type"] == "text"
         assert processed_history[0]["content"][1]["type"] == "tool_use"
         assert processed_history[0]["content"][1]["id"] == tool_id
-        
+
         # Message 2 (user with valid tool_result) should keep its structure
         assert processed_history[1]["role"] == "user"
         assert isinstance(processed_history[1]["content"], list)
         assert len(processed_history[1]["content"]) == 1
         assert processed_history[1]["content"][0]["type"] == "tool_result"
         assert processed_history[1]["content"][0]["tool_use_id"] == tool_id
-        
+
         # Message 3 (user with invalid tool_result) should be filtered
         assert processed_history[2]["role"] == "user"
         if isinstance(processed_history[2]["content"], list):
             assert len(processed_history[2]["content"]) == 0
         else:
             assert isinstance(processed_history[2]["content"], str)
-        
+
         # Message 4 (user with simple text) should remain unchanged
         assert processed_history[3]["role"] == "user"
         assert processed_history[3]["content"] == "Tell me more about mercy in the Quran."
-        
+
         print("All assertions passed - message processing correctly handled tool relationships!")
+
 
 if __name__ == "__main__":
     test_process_message_history_with_tools()

--- a/tests/unit/test_convert_message_llm.py
+++ b/tests/unit/test_convert_message_llm.py
@@ -15,55 +15,52 @@ def test_convert_message_llm_formats():
     settings.SECRET_KEY.get_secret_value.return_value = "test_secret_key"
     settings.ALGORITHM = "HS256"
     settings.ENCODING = "utf-8"
-    
-    with patch('psycopg2.pool.SimpleConnectionPool'):
+
+    with patch("psycopg2.pool.SimpleConnectionPool"):
         db = AnsariDB(settings)
-    
+
     # Test 1: Simple user message
     user_msg = ("user", "Hello, how are you?", None, None, None)
     result = db.convert_message_llm(user_msg)
-    
+
     assert len(result) == 1
     assert result[0]["role"] == "user"
     assert result[0]["content"] == "Hello, how are you?"
-    
+
     # Test 2: Simple assistant message
     assistant_msg = ("assistant", "I'm doing well, thank you!", None, None, None)
     result = db.convert_message_llm(assistant_msg)
-    
+
     assert len(result) == 1
     assert result[0]["role"] == "assistant"
     assert isinstance(result[0]["content"], list)
     assert len(result[0]["content"]) == 1
     assert result[0]["content"][0]["type"] == "text"
     assert result[0]["content"][0]["text"] == "I'm doing well, thank you!"
-    
+
     # Test 3: Assistant message with tool use
     tool_id = str(uuid.uuid4())
-    tool_details_json = json.dumps({
-        "id": tool_id,
-        "args": {"query": "mercy in quran"}
-    })
-    
+    tool_details_json = json.dumps({"id": tool_id, "args": {"query": "mercy in quran"}})
+
     assistant_tool_msg = ("assistant", "Let me search for that", "search_quran", tool_details_json, None)
     result = db.convert_message_llm(assistant_tool_msg)
-    
+
     assert len(result) == 1
     assert result[0]["role"] == "assistant"
     assert isinstance(result[0]["content"], list)
     assert len(result[0]["content"]) == 2  # text block + tool_use block
-    
+
     # Check text block
     assert result[0]["content"][0]["type"] == "text"
     assert result[0]["content"][0]["text"] == "Let me search for that"
-    
+
     # Check tool_use block
     assert result[0]["content"][1]["type"] == "tool_use"
     assert result[0]["content"][1]["id"] == tool_id
     assert result[0]["content"][1]["name"] == "search_quran"
-    
+
     print("All tests passed!")
-    
-    
+
+
 if __name__ == "__main__":
     test_convert_message_llm_formats()

--- a/tests/unit/test_main_api.py
+++ b/tests/unit/test_main_api.py
@@ -241,7 +241,7 @@ async def test_login_from_several_devices(register_user, login_user):
     # the other using the old one
     # Skip the async test calls in this test as we're just testing token refresh
     # If we need to actually test thread creation, this would need to be an async test
-    
+
     # Create a new thread using the old access token..
     # ..after logging out from the new device
     response = client.post(

--- a/tests/unit/test_multilingual_citations.py
+++ b/tests/unit/test_multilingual_citations.py
@@ -1,0 +1,194 @@
+"""Tests for multilingual citation format in search tools."""
+
+import json
+import pytest
+from ansari.util.translation import format_multilingual_data, parse_multilingual_data
+from ansari.tools.search_mawsuah import SearchMawsuah
+from ansari.tools.search_quran import SearchQuran
+from ansari.tools.search_hadith import SearchHadith
+
+
+class TestMultilingualFormat:
+    """Test the multilingual format utility functions."""
+
+    def test_format_multilingual_data(self):
+        """Test formatting a dictionary of language-text pairs to a JSON string."""
+        # Test with multiple languages
+        test_data = {"ar": "النص العربي", "en": "English text"}
+        result = format_multilingual_data(test_data)
+        assert isinstance(result, str)
+
+        # Verify the JSON structure
+        parsed = json.loads(result)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2
+
+        # Verify entries have lang and text
+        for item in parsed:
+            assert "lang" in item
+            assert "text" in item
+
+        # Verify correct data
+        langs = [item["lang"] for item in parsed]
+        assert "ar" in langs
+        assert "en" in langs
+
+    def test_parse_multilingual_data(self):
+        """Test parsing a JSON string to a dictionary of language-text pairs."""
+        # Create test JSON
+        json_str = json.dumps([{"lang": "ar", "text": "النص العربي"}, {"lang": "en", "text": "English text"}])
+
+        # Parse it
+        result = parse_multilingual_data(json_str)
+
+        # Verify result
+        assert isinstance(result, dict)
+        assert "ar" in result
+        assert "en" in result
+        assert result["ar"] == "النص العربي"
+        assert result["en"] == "English text"
+
+    def test_format_parse_roundtrip(self):
+        """Test round-trip from dict -> JSON string -> dict."""
+        original = {"ar": "النص العربي", "en": "English text", "fr": "Texte français"}
+
+        # Format to JSON string
+        json_str = format_multilingual_data(original)
+
+        # Parse back to dict
+        result = parse_multilingual_data(json_str)
+
+        # Verify round-trip consistency
+        assert result == original
+
+
+@pytest.fixture
+def mock_search_results_mawsuah():
+    """Mock results from the Mawsuah search tool."""
+    return {"search_results": [{"text": "نص عربي للاختبار", "score": 0.95}]}
+
+
+@pytest.fixture
+def mock_search_results_quran():
+    """Mock results from the Quran search tool."""
+    return [
+        {
+            "id": "1:1",
+            "text": "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ",
+            "en_text": "In the name of Allah, the Entirely Merciful, the Especially Merciful.",
+        }
+    ]
+
+
+@pytest.fixture
+def mock_search_results_hadith():
+    """Mock results from the Hadith search tool."""
+    return [
+        {
+            "id": "123",
+            "source_book": "Bukhari",
+            "chapter_number": "1",
+            "chapter_english": "Test Chapter",
+            "hadith_number": "456",
+            "section_number": "2",
+            "section_english": "Test Section",
+            "ar_text": "نص حديث عربي",
+            "en_text": "English hadith text",
+            "grade_en": "Sahih",
+        }
+    ]
+
+
+class TestSearchToolsFormat:
+    """Test that search tools correctly format their results in multilingual format."""
+
+    def test_mawsuah_format(self, mocker, mock_search_results_mawsuah):
+        """Test that SearchMawsuah correctly formats Arabic-only results."""
+        # Create a minimal mocked version of SearchMawsuah that overrides parent methods
+        mocker.patch(
+            "ansari.tools.search_vectara.SearchVectara.format_as_ref_list",
+            return_value=[
+                {
+                    "type": "document",
+                    "source": {"type": "text", "media_type": "text/plain", "data": "نص عربي للاختبار"},
+                    "title": "Test Document",
+                }
+            ],
+        )
+
+        # Instantiate with mock values
+        search = SearchMawsuah("mock_key", "mock_corpus")
+
+        # Format the results
+        formatted = search.format_as_ref_list(mock_search_results_mawsuah)
+
+        # Verify the result
+        assert isinstance(formatted, list)
+        assert len(formatted) == 1
+        doc = formatted[0]
+
+        # Verify document structure
+        assert doc["type"] == "document"
+        assert "source" in doc
+        assert "data" in doc["source"]
+
+        # Parse the multilingual data
+        data = parse_multilingual_data(doc["source"]["data"])
+
+        # Verify it contains Arabic only
+        assert "ar" in data
+        assert len(data) == 1  # Only Arabic, no other languages
+
+    def test_quran_format(self, mock_search_results_quran):
+        """Test that SearchQuran correctly formats bilingual results."""
+        # Instantiate with mock values
+        search = SearchQuran("mock_key")
+
+        # Format the results
+        formatted = search.format_as_ref_list(mock_search_results_quran)
+
+        # Verify the result
+        assert isinstance(formatted, list)
+        assert len(formatted) == 1
+        doc = formatted[0]
+
+        # Verify document structure
+        assert doc["type"] == "document"
+        assert "source" in doc
+        assert "data" in doc["source"]
+
+        # Parse the multilingual data
+        data = parse_multilingual_data(doc["source"]["data"])
+
+        # Verify it contains both Arabic and English
+        assert "ar" in data
+        assert "en" in data
+        assert len(data) == 2
+
+    def test_hadith_format(self, mock_search_results_hadith):
+        """Test that SearchHadith correctly formats results with metadata."""
+        # Instantiate with mock values
+        search = SearchHadith("mock_key")
+
+        # Format the results
+        formatted = search.format_as_ref_list(mock_search_results_hadith)
+
+        # Verify the result
+        assert isinstance(formatted, list)
+        assert len(formatted) == 1
+        doc = formatted[0]
+
+        # Verify document structure
+        assert doc["type"] == "document"
+        assert "source" in doc
+        assert "data" in doc["source"]
+
+        # Parse the multilingual data
+        data = parse_multilingual_data(doc["source"]["data"])
+
+        # Verify it contains both Arabic and English
+        assert "ar" in data
+        assert "en" in data
+
+        # Verify grade is in the title, not in the data
+        assert "Grade: Sahih" in doc["title"]

--- a/tests/unit/test_search_tafsir_encyc.py
+++ b/tests/unit/test_search_tafsir_encyc.py
@@ -7,7 +7,7 @@ settings = get_settings()
 
 # Set up logging
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 # Don't skip tests
 # pytestmark = pytest.mark.skipif(
@@ -27,13 +27,13 @@ class TestSearchTafsirEncyc:
         """Test searching with an Arabic query."""
         # Search for information about coral (marjaan) in the Quranic interpretation
         results = self.search_tool.run("مرجان", limit=3)
-        
+
         logger.info(f"Results: {results}")
-        
+
         # Basic validation of results
         assert "results" in results
         assert len(results["results"]) <= 3  # Should return at most 3 results
-        
+
         # Check the structure of the first result
         if results["results"]:
             first_result = results["results"][0]
@@ -42,7 +42,7 @@ class TestSearchTafsirEncyc:
             assert "node" in first_result
             assert "text" in first_result["node"]
             assert "score" in first_result
-            
+
             # Since include_chapters is set to True by default, check for chapter metadata
             # The chapter structure might be different than expected, so let's check for metadata
             assert "node" in first_result
@@ -53,9 +53,9 @@ class TestSearchTafsirEncyc:
         """Test searching with an English query."""
         # English query about coral in the Quran
         results = self.search_tool.run("coral in Quran", limit=3)
-        
+
         logger.info(f"English query results count: {len(results.get('results', []))}")
-        
+
         # Basic validation of results
         assert "results" in results
         assert len(results["results"]) <= 3  # Should return at most 3 results
@@ -64,16 +64,16 @@ class TestSearchTafsirEncyc:
         """Test formatting results as a reference list."""
         # First run a search to get real results
         raw_results = self.search_tool.run("مرجان", limit=2)
-        
+
         # Format the results
         formatted = self.search_tool.format_as_ref_list(raw_results)
-        
+
         logger.info(f"Formatted reference list (first item): {formatted[0] if formatted else 'None'}")
-        
+
         # Validate the formatted results
         assert isinstance(formatted, list)
         assert len(formatted) <= 2  # Should have at most 2 items
-        
+
         # Check the content of the first formatted result
         if formatted and not isinstance(formatted[0], str):
             first_formatted = formatted[0]
@@ -91,12 +91,12 @@ class TestSearchTafsirEncyc:
     def test_run_as_string(self):
         """Test running a search and getting results as a string."""
         result_string = self.search_tool.run_as_string("مرجان", limit=2)
-        
+
         logger.info(f"Result string (first 100 chars): {result_string[:100] if result_string else 'None'}")
-        
+
         # Validate the result string
         assert isinstance(result_string, str)
-        
+
         # Should contain typical parts of the formatted output
         if result_string != "No results found.":
             assert "Node ID:" in result_string
@@ -108,29 +108,29 @@ class TestSearchTafsirEncyc:
         # Note: Even with unlikely queries, the API might still return results
         # due to semantic search capabilities
         results = self.search_tool.run("xyzabcdefghijklmnopqrstuvwxyz123456789", limit=1)
-        
+
         logger.info(f"No results test - actual result count: {len(results.get('results', []))}")
-        
+
         # Instead of asserting there are no results, we'll test the formatting functions
         # which should handle both cases (results or no results) properly
-        
+
         # Create a mock empty result to test the no-results case
         empty_results = {"results": []}
-        
+
         # Check the formatted versions for empty results
         formatted_list = self.search_tool.format_as_ref_list(empty_results)
         assert len(formatted_list) == 1
         assert formatted_list[0] == "No results found."
-        
+
         formatted_tool_result = self.search_tool.format_as_tool_result(empty_results)
         assert formatted_tool_result["type"] == "text"
         assert formatted_tool_result["text"] == "No results found."
-        
+
         # Also verify that the actual API response (which might or might not have results)
         # can be properly formatted
         actual_formatted = self.search_tool.format_as_ref_list(results)
         assert isinstance(actual_formatted, list)
-        
+
         actual_tool_result = self.search_tool.format_as_tool_result(results)
         if len(results.get("results", [])) > 0:
             assert actual_tool_result["type"] == "array"
@@ -143,25 +143,25 @@ class TestSearchTafsirEncyc:
         """Test the format_as_tool_result method for Claude's expected format."""
         # First run a search to get real results
         raw_results = self.search_tool.run("مرجان", limit=2)
-        
+
         # Format the results for tool result
         formatted = self.search_tool.format_as_tool_result(raw_results)
-        
+
         logger.info(f"Tool result format: {formatted}")
-        
+
         # Validate the formatted results
         assert isinstance(formatted, dict)
-        
+
         # Check structure: either a text result or an array of items
         if len(raw_results.get("results", [])) > 0:
             assert formatted["type"] == "array"
             assert "items" in formatted
-            
+
             # Check content of items
             items = formatted["items"]
             assert isinstance(items, list)
             assert len(items) > 0
-            
+
             # Check first item structure
             first_item = items[0]
             logger.info(f"First item in tool result: {first_item}")
@@ -172,20 +172,20 @@ class TestSearchTafsirEncyc:
         else:
             assert formatted["type"] == "text"
             assert formatted["text"] == "No results found."
-        
+
     def test_format_tool_response(self):
         """Test the format_tool_response method for Claude's tool response format."""
         # First run a search to get real results
         raw_results = self.search_tool.run("مرجان", limit=2)
-        
+
         # Format as tool response
         tool_response = self.search_tool.format_tool_response(raw_results)
-        
+
         logger.info(f"Tool response format: {tool_response}")
-        
+
         # For Claude, the tool_result content should be a string
         assert isinstance(tool_response, str)
-        
+
         # If results were found, check that the message indicates there are results
         if len(raw_results.get("results", [])) > 0:
             assert "Please see the included reference list" in tool_response
@@ -195,4 +195,4 @@ class TestSearchTafsirEncyc:
 
 if __name__ == "__main__":
     # This allows running the tests directly
-    pytest.main(["-xvs", __file__]) 
+    pytest.main(["-xvs", __file__])

--- a/tests/unit/test_translation.py
+++ b/tests/unit/test_translation.py
@@ -5,7 +5,7 @@ from ansari.util.translation import translate_text
 
 # Set up logging
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 
 class TestTranslation:
@@ -15,7 +15,7 @@ class TestTranslation:
         """Test translating the Basmalah from Arabic to English."""
         basmalah = "بسم الله الرحمن الرحيم"
         result = translate_text(basmalah, "en", "ar")
-        
+
         logger.info(f"Basmalah translation: '{result}'")
         assert result, "Translation should not be empty"
 
@@ -24,7 +24,7 @@ class TestTranslation:
         # No API call made when languages match
         text = "Hello world"
         result = translate_text(text, "en", "en")
-        
+
         # Should return the original text unchanged
         assert result == text
 
@@ -32,7 +32,7 @@ class TestTranslation:
         """Test translating empty text."""
         # No API call made for empty text
         result = translate_text("", "ar", "en")
-        
+
         # Should return empty string
         assert result == ""
 


### PR DESCRIPTION
## Summary

- Adds JSON-based multilingual data structure to document citations
- Prevents duplicate translations for search tools with built-in translations (Quran, Hadith)
- Only translates content when necessary, improving efficiency
- Adds comprehensive tests and updates documentation

## Test plan
1. Run the new tests: ============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/mwk/Development/ansari-project/ansari-backend
configfile: pytest.ini
plugins: asyncio-0.25.3, anyio-4.8.0, timeout-2.3.1, mock-3.14.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function
collected 6 items

tests/unit/test_multilingual_citations.py ......                         [100%]

============================== 6 passed in 0.38s ===============================
2. Test citations from search_quran tool - verify translations aren't duplicated
3. Test citations from search_mawsuah tool - verify translation happens once
4. Verify code follows style guidelines with test_ansari_claude.py:3:8: F401 [*] `json` imported but unused
  |
1 | #\!/usr/bin/env python
2 | 
3 | import json
  |        ^^^^ F401
4 | import os
5 | import sys
  |
  = help: Remove unused import: `json`

test_ansari_claude.py:4:8: F401 [*] `os` imported but unused
  |
3 | import json
4 | import os
  |        ^^ F401
5 | import sys
  |
  = help: Remove unused import: `os`

tests/integration/test_helpers.py:169:128: E501 Line too long (130 > 127)
    |
167 |                 hist_json = json.dumps(hist_msg["content"], sort_keys=True)
168 |                 log_json = json.dumps(log_msg["content"], sort_keys=True)
169 |                 assert hist_json == log_json, f"Message {i} content structure mismatch:\nHistory: {hist_json}\nLogger: {log_json}"
    |                                                                                                                                ^^^ E501
170 |             elif (isinstance(hist_msg["content"], str) and 
171 |                   isinstance(log_msg["content"], (list, dict))):
    |

tests/integration/test_helpers.py:179:128: E501 Line too long (131 > 127)
    |
177 |             else:
178 |                 # If types don't match and it's not a known conversion case
179 |                 logger.warning(f"Content type mismatch for message {i}: {type(hist_msg['content'])} vs {type(log_msg['content'])}")
    |                                                                                                                                ^^^^ E501
180 |                 logger.warning("This might be normal for some agent implementations.")
181 |                 # We don't assert here as different implementations may store content differently
    |

tests/unit/test_ansari_claude_message_sequence.py:1:8: F401 [*] `json` imported but unused
  |
1 | import json
  |        ^^^^ F401
2 | import uuid
3 | import sys
  |
  = help: Remove unused import: `json`

tests/unit/test_ansari_claude_tool_sequence.py:1:8: F401 [*] `json` imported but unused
  |
1 | import json
  |        ^^^^ F401
2 | import uuid
3 | import sys
  |
  = help: Remove unused import: `json`

tests/unit/test_search_mawsuah.py:3:8: F401 [*] `asyncio` imported but unused
  |
1 | import pytest
2 | import logging
3 | import asyncio
  |        ^^^^^^^ F401
4 | import time
5 | import json
  |
  = help: Remove unused import: `asyncio`

tests/unit/test_search_mawsuah.py:5:8: F401 [*] `json` imported but unused
  |
3 | import asyncio
4 | import time
5 | import json
  |        ^^^^ F401
6 | import requests
7 | from unittest.mock import patch, MagicMock, Mock
  |
  = help: Remove unused import: `json`

tests/unit/test_search_mawsuah.py:6:8: F401 [*] `requests` imported but unused
  |
4 | import time
5 | import json
6 | import requests
  |        ^^^^^^^^ F401
7 | from unittest.mock import patch, MagicMock, Mock
  |
  = help: Remove unused import: `requests`

tests/unit/test_search_mawsuah.py:7:34: F401 [*] `unittest.mock.MagicMock` imported but unused
  |
5 | import json
6 | import requests
7 | from unittest.mock import patch, MagicMock, Mock
  |                                  ^^^^^^^^^ F401
8 | 
9 | from ansari.tools.search_mawsuah import SearchMawsuah
  |
  = help: Remove unused import

tests/unit/test_search_mawsuah.py:7:45: F401 [*] `unittest.mock.Mock` imported but unused
  |
5 | import json
6 | import requests
7 | from unittest.mock import patch, MagicMock, Mock
  |                                             ^^^^ F401
8 | 
9 | from ansari.tools.search_mawsuah import SearchMawsuah
  |
  = help: Remove unused import

tests/unit/test_search_mawsuah.py:10:37: F401 [*] `ansari.util.translation.translate_text` imported but unused
   |
 9 | from ansari.tools.search_mawsuah import SearchMawsuah
10 | from ansari.util.translation import translate_text, translate_texts_parallel
   |                                     ^^^^^^^^^^^^^^ F401
11 | from ansari.config import get_settings
   |
   = help: Remove unused import: `ansari.util.translation.translate_text`

Found 12 errors.
[*] 10 fixable with the `--fix` option.