### PR TITLE
Fix bug with JSON in citations for Quran searches

### DIFF
--- a/src/ansari/cli/use_tools.py
+++ b/src/ansari/cli/use_tools.py
@@ -81,7 +81,9 @@ def pretty_print_results(results: Any, output_format: str) -> None:
 def create_search_tool(tool_name: str) -> Any:
     """Create and return the appropriate search tool instance based on the tool name."""
     tools = {
-        "hadith": lambda: SearchHadith(),
+        "hadith": lambda: SearchHadith(
+            kalimat_api_key=settings.KALEMAT_API_KEY.get_secret_value() if hasattr(settings, "KALEMAT_API_KEY") else ""
+        ),
         "mawsuah": lambda: SearchMawsuah(
             vectara_api_key=settings.VECTARA_API_KEY.get_secret_value(), vectara_corpus_key=settings.MAWSUAH_CORPUS_ID
         ),

--- a/src/ansari/tools/search_hadith.py
+++ b/src/ansari/tools/search_hadith.py
@@ -92,19 +92,14 @@ class SearchHadith:
             if grade:
                 title += f" (Grade: {grade})"
 
-            # Prepare multilingual data for hadith content
-            text_entries = {}
-            if ar_text:
-                text_entries["ar"] = ar_text
-            if text:
-                text_entries["en"] = text
-
-            # Convert to JSON format for multilingual support
-            multilingual_data = format_multilingual_data(text_entries)
-
+            # Only include text (Arabic preferred, English as fallback) in the document data
+            # We'll handle translation in the citation processing code
+            # Use Arabic text if available, otherwise fallback to English text
+            doc_text = ar_text if ar_text else text
+            
             document = {
                 "type": "document",
-                "source": {"type": "text", "media_type": "text/plain", "data": multilingual_data},
+                "source": {"type": "text", "media_type": "text/plain", "data": doc_text},
                 "title": title,
                 "context": "Retrieved from hadith collections",
                 "citations": {"enabled": True},

--- a/src/ansari/tools/search_quran.py
+++ b/src/ansari/tools/search_quran.py
@@ -105,12 +105,15 @@ class SearchQuran:
             # Create citation title
             title = f"Quran {id}"
 
-            # Only include Arabic text in the document data that Claude will see and cite
+            # Only include text (Arabic preferred, English as fallback) in the document data
             # We'll handle translation in the citation processing code
+            # Use Arabic text if available, otherwise fallback to English text
+            doc_text = arabic if arabic else english
+            
             documents.append(
                 {
                     "type": "document",
-                    "source": {"type": "text", "media_type": "text/plain", "data": arabic},
+                    "source": {"type": "text", "media_type": "text/plain", "data": doc_text},
                     "title": title,
                     "context": "Retrieved from the Holy Quran",
                     "citations": {"enabled": True},

--- a/src/ansari/tools/search_quran.py
+++ b/src/ansari/tools/search_quran.py
@@ -105,14 +105,12 @@ class SearchQuran:
             # Create citation title
             title = f"Quran {id}"
 
-            # Format as multilingual data with both Arabic and English
-            # Note: Quran search results already include both Arabic and English translations
-            multilingual_data = format_multilingual_data({"ar": arabic, "en": english})
-
+            # Only include Arabic text in the document data that Claude will see and cite
+            # We'll handle translation in the citation processing code
             documents.append(
                 {
                     "type": "document",
-                    "source": {"type": "text", "media_type": "text/plain", "data": multilingual_data},
+                    "source": {"type": "text", "media_type": "text/plain", "data": arabic},
                     "title": title,
                     "context": "Retrieved from the Holy Quran",
                     "citations": {"enabled": True},

--- a/tests/unit/test_citation_formatting.py
+++ b/tests/unit/test_citation_formatting.py
@@ -1,0 +1,130 @@
+"""Tests for citation formatting in Quran and Hadith searches."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+import json
+
+from ansari.tools.search_quran import SearchQuran
+from ansari.tools.search_hadith import SearchHadith
+from ansari.agents.ansari_claude import AnsariClaude
+from ansari.config import Settings
+
+
+class TestCitationFormatting(unittest.TestCase):
+    """Tests to verify that citations are properly formatted without JSON data."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create mock settings
+        self.settings = Settings(
+            OPENAI_API_KEY="mock-openai-key",
+            ANTHROPIC_API_KEY="mock-anthropic-key",
+            KALEMAT_API_KEY="mock-kalemat-key",
+            ANTHROPIC_MODEL="claude-3-opus-20240229",
+            DEBUG_MODE=True,
+        )
+        
+        # Create mock MessageLogger
+        self.message_logger = MagicMock()
+        
+        # Initialize an AnsariClaude agent with mock settings and logger
+        self.agent = AnsariClaude(self.settings, self.message_logger)
+
+    @patch('ansari.tools.search_quran.SearchQuran.run')
+    def test_quran_search_sleeplessness_citation_format(self, mock_run):
+        """Test that Quran search for 'sleeplessness' doesn't return JSON in citations."""
+        # Mock the API response for Quran search
+        mock_results = [
+            {
+                "id": "25:47",
+                "text": "وَهُوَ ٱلَّذِى جَعَلَ لَكُمُ ٱلَّيْلَ لِبَاسًا وَٱلنَّوْمَ سُبَاتًا وَجَعَلَ ٱلنَّهَارَ نُشُورًا",
+                "en_text": "He is the One Who has made the night for you as a cover, and made sleep for resting, and the day for rising."
+            },
+            {
+                "id": "78:9",
+                "text": "وَجَعَلْنَا نَوْمَكُمْ سُبَاتًا",
+                "en_text": "and made your sleep for rest,"
+            }
+        ]
+        mock_run.return_value = mock_results
+        
+        # Create a Quran search tool instance
+        quran_tool = SearchQuran(kalimat_api_key="mock-key")
+        
+        # Get ref_list from the tool
+        ref_list = quran_tool.format_as_ref_list(mock_results)
+        
+        # Check that the data field doesn't contain JSON
+        for doc in ref_list:
+            self.assertIsInstance(doc, dict)
+            self.assertIn("source", doc)
+            self.assertIn("data", doc["source"])
+            data = doc["source"]["data"]
+            
+            # Verify data is just text, not JSON
+            with self.assertRaises(ValueError):
+                # This should raise ValueError since data is not JSON
+                json.loads(data)
+            
+            # Verify data is the Arabic text
+            self.assertTrue(
+                data == mock_results[0]["text"] or data == mock_results[1]["text"],
+                f"Expected data to be Arabic text, but got: {data}"
+            )
+
+    @patch('ansari.tools.search_hadith.SearchHadith.run')
+    def test_hadith_search_day_of_judgment_citation_format(self, mock_run):
+        """Test that Hadith search for 'signs of the day of judgment' doesn't return JSON in citations."""
+        # Mock the API response for Hadith search
+        mock_results = [
+            {
+                "id": "1_2_37_50",
+                "source_book": "Bukhari",
+                "chapter_number": "2",
+                "chapter_english": "Belief",
+                "section_number": "37",
+                "section_english": "The asking of Jibreel about Iman, Islam, Ihsan",
+                "hadith_number": "50",
+                "ar_text": "عَنْ أَبِي هُرَيْرَةَ، قَالَ كَانَ النَّبِيُّ صلى الله عليه وسلم بَارِزًا يَوْمًا لِلنَّاسِ...",
+                "en_text": "Narrated Abu Huraira: One day while the Prophet (ﷺ) was sitting in the company of some people, (The angel) Gabriel came and asked, \"What is faith?\"...",
+                "grade_en": "Sahih-Authentic"
+            },
+            {
+                "id": "3_39_1598_4178",
+                "source_book": "AbuDaud",
+                "chapter_number": "39",
+                "chapter_english": "Battles",
+                "section_number": "1598",
+                "section_english": "Signs of the hour",
+                "hadith_number": "4178",
+                "ar_text": "قال رسول الله صلى الله عليه وسلم: لا تقوم الساعة حتى تكون عشر آيات...",
+                "en_text": "The Messenger of Allah (peace be upon him) said: The last hour will not come or happen until there appear ten signs before it...",
+                "grade_en": "Sahih - Authentic"
+            }
+        ]
+        mock_run.return_value = mock_results
+        
+        # Create a Hadith search tool instance
+        hadith_tool = SearchHadith(kalimat_api_key="mock-key")
+        
+        # Get ref_list from the tool
+        ref_list = hadith_tool.format_as_ref_list(mock_results)
+        
+        # Check that the data field doesn't contain JSON
+        for doc in ref_list:
+            self.assertIsInstance(doc, dict)
+            self.assertIn("source", doc)
+            self.assertIn("data", doc["source"])
+            data = doc["source"]["data"]
+            
+            # Verify data is just text, not JSON
+            with self.assertRaises(ValueError):
+                # This should raise ValueError since data is not JSON
+                json.loads(data)
+            
+            # Verify data is the Arabic text or English text (fallback)
+            self.assertTrue(
+                data == mock_results[0]["ar_text"] or data == mock_results[1]["ar_text"] or
+                data == mock_results[0]["en_text"] or data == mock_results[1]["en_text"],
+                f"Expected data to be text, but got: {data}"
+            )


### PR DESCRIPTION
## Summary
- Fixed a bug where JSON was appearing in the Arabic and English fields of Quran citations
- Modified search_quran.py to only store Arabic text in document data
- Updated citation handling to always translate Arabic text to English
- Added extra newlines between Arabic and English in citation output for better readability

## Test plan
- Test by querying 'what does the quran say about sleeplessness?' and verify no JSON appears in citations
