### PR TITLE
Fix Claude response completion handling for both local and production environments

### DIFF
--- a/tests/unit/test_ansari_claude_message_sequence.py
+++ b/tests/unit/test_ansari_claude_message_sequence.py
@@ -75,7 +75,18 @@ def test_message_sequence_with_tool_use():
         # Mock the API response to avoid actual API calls
         mock_response = MagicMock()
         claude.client.messages.create.return_value = mock_response
-        claude.process_one_round = MagicMock(return_value=[])
+        
+        # Create a more sophisticated mock for process_one_round
+        # This will append an assistant message to message_history to break the loop
+        def mock_process_one_round(*args, **kwargs):
+            # Add an assistant message to break the loop in process_message_history
+            claude.message_history.append({
+                "role": "assistant",
+                "content": [{"type": "text", "text": "I've processed your request."}]
+            })
+            return ["I've processed your request."]
+            
+        claude.process_one_round = MagicMock(side_effect=mock_process_one_round)
 
         # Run the message processing
         # Make a copy of the history for comparison

--- a/tests/unit/test_logging_regression.py
+++ b/tests/unit/test_logging_regression.py
@@ -1,0 +1,64 @@
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+# Add the src directory to the path so we can import the modules
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+sys.path.insert(0, src_path)
+
+from ansari.agents.ansari_claude import AnsariClaude
+from ansari.config import Settings
+
+
+def test_logging_changes_dont_break_basic_functionality():
+    """
+    Test that our logging changes don't break basic functionality.
+    This is a minimal test to verify nothing fundamental was broken.
+    """
+    # Create a mock settings object
+    settings = MagicMock(spec=Settings)
+    settings.ANTHROPIC_MODEL = "claude-3-opus-20240229"
+    settings.MAX_FAILURES = 3
+
+    # Create a mocked AnsariClaude instance with initial tools setup
+    with patch("anthropic.Anthropic"), patch.object(AnsariClaude, "__init__", return_value=None):
+        claude = AnsariClaude.__new__(AnsariClaude)
+        claude.settings = settings
+        claude.message_logger = None
+        
+        # Set needed attributes that would normally be set in __init__
+        claude.tools = []
+        claude.tool_name_to_instance = {}
+        claude.citations = []
+        claude.message_history = []
+        claude.client = MagicMock()
+
+        # Set up a simple message history
+        claude.message_history = [
+            {"role": "user", "content": "Hello, world!"}
+        ]
+        
+        # Mock the API response to avoid actual API calls
+        claude.process_one_round = MagicMock(side_effect=lambda: [])
+        
+        # Add an assistant response
+        claude.message_history.append({
+            "role": "assistant", 
+            "content": [{"type": "text", "text": "Hello! How can I help you today?"}]
+        })
+        
+        # Verify basic validation works
+        assert claude.validate_message(claude.message_history[-1]) == True
+        
+        # Test message logging works
+        claude.message_logger = MagicMock()
+        claude._log_message(claude.message_history[-1])
+        
+        # Verify logger was called
+        claude.message_logger.log.assert_called_once()
+        
+        print("Test passed - basic functionality works!")
+
+
+if __name__ == "__main__":
+    test_logging_changes_dont_break_basic_functionality()


### PR DESCRIPTION
## Summary
- Fixed issue with message completion handling that affects production environments
- Added proper handling for both message_stop (local) and message_delta with end_turn (production)
- Prevents duplicate assistant messages by tracking response completion state

## Test plan
- Ran existing unit tests to confirm functionality works
- Manual testing shows the fix properly handles message completion in production

This PR fixes a critical issue where conversations in production would become corrupted or terminated early because the LLM client code was only handling message_stop events but not the end_turn stop_reason in message_delta events.