### PR TITLE
Add PyPI packaging support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,9 @@
 - Run tests with specific marker: `pytest -m integration`
 - Lint code: `ruff check src/`
 - Format code: `ruff format src/`
+- Package commands:
+  - Build package: `python -m build`
+  - Upload to PyPI: `twine upload dist/*` (requires PyPI credentials)
 
 ## Code Style Guidelines
 - **Imports**: Use absolute imports within the `ansari` package

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ansari Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include README.md
+include LICENSE
+include requirements.txt
+include pyproject.toml
+include MANIFEST.in
+
+recursive-include src/ansari/resources *
+recursive-include src/ansari/templates *

--- a/README.md
+++ b/README.md
@@ -4,9 +4,30 @@ _Try Ansari now at [ansari.chat](https://ansari.chat)!_
 
 Ansari is an **experimental open source project** that explores the application of large language models in helping Muslims improve their practice of Islam and non-Muslims develop an accurate understanding of the teachings of Islam. 
 
-It is not always correct and can get things wrong.  The list below includes some of the issues we’ve seen in working with Ansari. 
+It is not always correct and can get things wrong.  The list below includes some of the issues we've seen in working with Ansari. 
 
 It uses carefully crafted prompts and several sources accessed through retrieval augmented generation. 
+
+## Installation
+
+You can install the Ansari backend from PyPI:
+
+```bash
+pip install ansari-backend
+```
+
+Once installed, you can use the command-line interface:
+
+```bash
+# Interactive mode
+ansari
+
+# With direct input
+ansari -i "your question here"
+
+# Using Claude agent
+ansari -a AnsariClaude
+```
 
 ***TOC***
 
@@ -48,8 +69,8 @@ A complete list of what Ansari can do can be found [here](https://ansari.chat/do
 
 # What is logged with Ansari?
 
-* Only the conversations are logged. Nothing incidental about your identity is currently retained: no ip address, no  accounts etc. If you share personal details with Ansari as part of a conversation e.g. “my name is Mohammed Ali” that will be logged. 
-* If you shared something that shouldn’t have been shared, drop us an e-mail at feedback@ansari.chat and we can delete any logs. 
+* Only the conversations are logged. Nothing incidental about your identity is currently retained: no ip address, no  accounts etc. If you share personal details with Ansari as part of a conversation e.g. "my name is Mohammed Ali" that will be logged. 
+* If you shared something that shouldn't have been shared, drop us an e-mail at feedback@ansari.chat and we can delete any logs. 
 
 # Getting the Ansari Backend running on your local machine 
 
@@ -177,13 +198,13 @@ Side note: If you're contributing to the [main project](https://github.com/ansar
 
 # The Roadmap
 
-This roadmap is preliminary, but it gives you an idea of where Ansari is heading. Please contact us at `feedback@ansari.chat `if you’d like to help with these.  
+This roadmap is preliminary, but it gives you an idea of where Ansari is heading. Please contact us at `feedback@ansari.chat `if you'd like to help with these.  
 
 
 
 * ~~Add feedback buttons to the UI (thumbs up, thumbs down, explanation)~~
-* ~~Add “share” button to the UI that captures a conversation and gives you a URL for it to share with friends. ~~
-* ~~Add “share Ansari” web site.~~ 
+* ~~Add "share" button to the UI that captures a conversation and gives you a URL for it to share with friends. ~~
+* ~~Add "share Ansari" web site.~~ 
 * ~~Improve logging of chats – move away from PromptLayer.~~
 * ~~Add Hadith Search. ~~
 * Improve source citation. 
@@ -205,8 +226,7 @@ This roadmap is preliminary, but it gives you an idea of where Ansari is heading
 
 
 * Amin Ahmad: general advice on LLMs, integration with vector databases. 
-* Hossam Hassan: vector database backend for Qur’an search. 
+* Hossam Hassan: vector database backend for Qur'an search. 
 * Saifeldeen Hadid: testing and identifying issues. 
 * Iman Sadreddin: Identifying output issues. 
 * Wael Hamza: Characterizing output. 
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,52 @@ description = "Ansari is an AI assistant to enhance understanding and practice o
 authors = [
     { name = "Ansari Project", email = "feedback@ansari.chat" }
 ]
+readme = "README.md"
 requires-python = ">=3.8"
+license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "bcrypt",
+    "diskcache",
+    "email-validator",
+    "fastapi",
+    "jinja2",
+    "langdetect",
+    "litellm>=1.59.6,<1.59.9",
+    "loguru",
+    "openai",
+    "pandas",
+    "psycopg2-binary",
+    "pydantic_settings",
+    "pyjwt",
+    "rich",
+    "sendgrid",
+    "sentry-sdk[fastapi]",
+    "tenacity",
+    "tiktoken",
+    "typer",
+    "uvicorn",
+    "zxcvbn",
+    "anthropic",
+]
 
 [project.urls]
 Homepage = "https://github.com/ansari-project/ansari-backend"
 Documentation = "https://github.com/ansari-project/ansari-backend"
 Source = "https://github.com/ansari-project/ansari-backend"
 Tracker = "https://github.com/ansari-project/ansari-backend/issues"
+
+[project.scripts]
+ansari = "ansari.app.main_stdio:main"
 
 [tool.ruff]
 line-length = 127

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pydantic_settings
 pyjwt
 pytest-asyncio
 pytest-mock
+pytest-xdist
 rich
 sendgrid
 sentry-sdk[fastapi]

--- a/src/ansari/agents/ansari_claude.py
+++ b/src/ansari/agents/ansari_claude.py
@@ -855,7 +855,7 @@ class AnsariClaude(Ansari):
                     # Add a text-only message indicating the loop
                     self.message_history.append({
                         "role": "assistant", 
-                        "content": [{"type": "text", "text": "I got stuck in a loop. Let me try again or please rephrase your question."}]
+                        "content": [{"type": "text", "text": "I got stuck in a loop. Please rephrase your question."}]
                     })
                     # Log this message
                     self._log_message(self.message_history[-1])

--- a/src/ansari/app/main_api_client.py
+++ b/src/ansari/app/main_api_client.py
@@ -8,8 +8,6 @@ offers a similar interface to main_stdio.py.
 import logging
 import typer
 import requests
-import json
-import uuid
 import random
 import string
 import time
@@ -18,7 +16,6 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from ansari.ansari_logger import get_logger
-from ansari.config import get_settings
 
 logger = get_logger(__name__)
 app = typer.Typer()
@@ -28,7 +25,9 @@ console = Console()
 class AnsariApiClient:
     """Client for interacting with the Ansari API."""
     
-    def __init__(self, base_url, email=None, password=None, origin="http://localhost:3000", mobile_header=False, json_mode=False):
+    def __init__(
+        self, base_url, email=None, password=None, origin="http://localhost:3000", mobile_header=False, json_mode=False
+    ):
         self.base_url = base_url
         self.email = email
         self.password = password


### PR DESCRIPTION

This PR prepares the ansari-backend package for distribution via PyPI, allowing users to install it with `pip install ansari-backend`. This is primarily so that other projects (e.g. Haadi) can use Ansari directly (without having to do multiple hops). 

  ### Changes:

  - Update `pyproject.toml` with complete package metadata:
    - Add dependencies from requirements.txt
    - Add project classifiers and license info
    - Define CLI entry point: `ansari = "ansari.app.main_stdio:main"`

  - Add MIT license file
  - Create MANIFEST.in to include non-Python files (templates, prompts)
  - Fix linting issues in codebase
  - Add installation and usage instructions to README.md

  ### Testing:

  - Successfully built package with `python -m build`
  - Verified package includes all necessary files
  - Confirmed entry point script works as expected
