### PR TITLE
Remove message IDs before sending to Claude API

### DIFF
--- a/src/ansari/agents/ansari_claude.py
+++ b/src/ansari/agents/ansari_claude.py
@@ -233,7 +233,15 @@ class AnsariClaude(Ansari):
         and then processes it to generate a response from Ansari.
         """
         # AnsariClaude doesn't use system message, so we don't need to prefix it
-        self.message_history = message_history
+        # Remove message IDs from the history before sending to Claude
+        cleaned_history = []
+        for msg in message_history:
+            msg_copy = msg.copy()
+            if "id" in msg_copy:
+                del msg_copy["id"]
+            cleaned_history.append(msg_copy)
+
+        self.message_history = cleaned_history
 
         for m in self.process_message_history(use_tool, stream):
             if m:


### PR DESCRIPTION
## Summary
- The database now includes message IDs in thread responses for thumbs up/down functionality
- However, these message IDs shouldn't be sent to Claude as they are internal identifiers
- Fixed by cleaning message history before sending to Claude API

## Test plan
- Messages sent to Claude no longer contain ID fields
- Message history returned to clients still contains IDs for UI features