### PR TITLE
Registers users to the mailing list during signup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ OPENAI_API_KEY=""           # Token for GPT-4 (Optional)
 # Optional. If not set, the app will not use these services.
 SENDGRID_API_KEY=""         # API key to send password reset options
 
+MAILCHIMP_API_KEY=""         # API key
+MAILCHIMP_SERVER_PREFIX="" # Server prefix (data center)
+MAILCHIMP_LIST_ID=""      # List ID
+
 # Database connection string
 MONGO_URL="mongodb://localhost:27017"
 MONGO_DB_NAME="ansari_db"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -53,6 +53,9 @@ jobs:
 
           OPENAI_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'openai-api-key') }}
           SENDGRID_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'sendgrid-api-key') }}
+          MAILCHIMP_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mailchimp-api-key') }}
+          MAILCHIMP_SERVER_PREFIX: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mailchimp-server-prefix') }}
+          MAILCHIMP_LIST_ID: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mailchimp-list-id') }}
           ANTHROPIC_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'anthropic-api-key') }}
           KALEMAT_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'kalemat-api-key') }}
           SUNNAH_TOKEN: ${{ format('{0}{1}', secrets.SSM_ROOT, 'sunnah-token') }}
@@ -93,6 +96,9 @@ jobs:
 
             OPENAI_API_KEY
             SENDGRID_API_KEY
+            MAILCHIMP_API_KEY
+            MAILCHIMP_SERVER_PREFIX
+            MAILCHIMP_LIST_ID
             ANTHROPIC_API_KEY
             KALEMAT_API_KEY
             SUNNAH_TOKEN

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,6 +53,9 @@ jobs:
 
           OPENAI_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'openai-api-key') }}
           SENDGRID_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'sendgrid-api-key') }}
+          MAILCHIMP_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mailchimp-api-key') }}
+          MAILCHIMP_SERVER_PREFIX: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mailchimp-server-prefix') }}
+          MAILCHIMP_LIST_ID: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mailchimp-list-id') }}
           ANTHROPIC_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'anthropic-api-key') }}
           KALEMAT_API_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'kalemat-api-key') }}
           SUNNAH_TOKEN: ${{ format('{0}{1}', secrets.SSM_ROOT, 'sunnah-token') }}
@@ -93,6 +96,9 @@ jobs:
 
             OPENAI_API_KEY
             SENDGRID_API_KEY
+            MAILCHIMP_API_KEY
+            MAILCHIMP_SERVER_PREFIX
+            MAILCHIMP_LIST_ID
             ANTHROPIC_API_KEY
             KALEMAT_API_KEY
             SUNNAH_TOKEN

--- a/src/ansari/app/main_api.py
+++ b/src/ansari/app/main_api.py
@@ -41,7 +41,7 @@ from ansari.ansari_logger import get_logger
 from ansari.app.main_whatsapp import router as whatsapp_router
 from ansari.config import Settings, get_settings
 from ansari.presenters.api_presenter import ApiPresenter
-from ansari.util.general_helpers import CORSMiddlewareWithLogging, get_extended_origins
+from ansari.util.general_helpers import CORSMiddlewareWithLogging, get_extended_origins, register_to_mailing_list
 
 logger = get_logger(__name__)
 deployment_type = get_settings().DEPLOYMENT_TYPE
@@ -185,6 +185,7 @@ class RegisterRequest(BaseModel):
     password: str
     first_name: str
     last_name: str
+    register_to_mail_list: bool = False
     # Left as an optional field for now to avoid breaking the frontend
     #   (I.e., the frontend doesn't send this field yet)
     source: SourceType = SourceType.WEB
@@ -227,13 +228,23 @@ async def register_user(req: RegisterRequest):
                 status_code=400,
                 detail="Password is too weak. Suggestions: " + ",".join(passwd_quality["feedback"]["suggestions"]),
             )
-        return db.register(
+
+        result = db.register(
             source=req.source,
             email=req.email,
             first_name=req.first_name,
             last_name=req.last_name,
             password_hash=password_hash,
         )
+
+        if result["status"] == "success" and req.register_to_mail_list:
+            try:
+                register_to_mailing_list(req.email, req.first_name, req.last_name)
+            except Exception as e:
+                logger.error(f"Error registering to Mailchimp: {e}")
+                sentry_sdk.capture_exception(e)
+
+        return result
     except HTTPException:
         # Re-raise HTTP exceptions
         raise

--- a/src/ansari/config.py
+++ b/src/ansari/config.py
@@ -174,6 +174,9 @@ class Settings(BaseSettings):
 
     DISCORD_TOKEN: SecretStr | None = Field(default=None)
     SENDGRID_API_KEY: SecretStr | None = Field(default=None)
+    MAILCHIMP_API_KEY: SecretStr | None = Field(default=None)
+    MAILCHIMP_SERVER_PREFIX: str | None = Field(default=None)
+    MAILCHIMP_LIST_ID: str | None = Field(default=None)
     QURAN_DOT_COM_API_KEY: SecretStr = Field(alias="QURAN_DOT_COM_API_KEY")
     WHATSAPP_ENABLED: bool = Field(default=True)
     WHATSAPP_API_VERSION: str | None = Field(default="v22.0")


### PR DESCRIPTION
THis PR registers users to the mailing list during the signup process using Mailchimp.

The update requires 3 new env vars which have been added to AWS staging and production.

Mailchimp offers a Python package but all we need at this stage is a single REST API call which is called directly if the user opts to the mailing list.

The REST API uses basic authentication (user/pass) but Mailchimp only uses a single API key hence the use of a 'anystring' in the username.