### PR TITLE
Update the reset password template to use the relevant environment frontend URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DEPLOYMENT_TYPE="development"    # Deployment type (development, staging, production)
+FRONTEND_URL="http://localhost:8081"
 
 KALEMAT_API_KEY=""          # Token for Qur'an and Hadith search
 ANTHROPIC_API_KEY=""        # API key for Claude AI model

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           DEPLOYMENT_TYPE: production
           LOGGING_LEVEL: INFO
+          FRONTEND_URL: ${{ format('{0}{1}', secrets.SSM_ROOT, 'frontend-url') }}
           MONGO_URL: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mongo-url') }}
           MONGO_DB_NAME: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mongo-db-name') }}
           SECRET_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'secret-key') }}
@@ -89,6 +90,7 @@ jobs:
             DEPLOYMENT_TYPE
             LOGGING_LEVEL
           copy-secret-env-vars: |
+            FRONTEND_URL
             MONGO_URL
             MONGO_DB_NAME
             SECRET_KEY

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           DEPLOYMENT_TYPE: staging
           LOGGING_LEVEL: DEBUG
+          FRONTEND_URL: ${{ format('{0}{1}', secrets.SSM_ROOT, 'frontend-url') }}
           MONGO_URL: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mongo-url') }}
           MONGO_DB_NAME: ${{ format('{0}{1}', secrets.SSM_ROOT, 'mongo-db-name') }}
           SECRET_KEY: ${{ format('{0}{1}', secrets.SSM_ROOT, 'secret-key') }}
@@ -89,6 +90,7 @@ jobs:
             DEPLOYMENT_TYPE
             LOGGING_LEVEL
           copy-secret-env-vars: |
+            FRONTEND_URL
             MONGO_URL
             MONGO_DB_NAME
             SECRET_KEY

--- a/src/ansari/app/main_api.py
+++ b/src/ansari/app/main_api.py
@@ -789,7 +789,7 @@ async def request_password_reset(
         # shall we also revoke login and refresh tokens?
         tenv = Environment(loader=FileSystemLoader(settings.template_dir))
         template = tenv.get_template("password_reset.html")
-        rendered_template = template.render(reset_token=reset_token)
+        rendered_template = template.render(reset_token=reset_token, frontend_url=settings.FRONTEND_URL)
         message = Mail(
             from_email=Email("feedback@ansari.chat"),
             to_emails=To(req.email),

--- a/src/ansari/config.py
+++ b/src/ansari/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
         return path
 
     DEPLOYMENT_TYPE: str = Field(default="development")
+    FRONTEND_URL: str = Field(default="https://ansari.chat")
     SENTRY_DSN: HttpUrl | None = None
 
     DATABASE_URL: PostgresDsn = Field(

--- a/src/ansari/resources/templates/password_reset.html
+++ b/src/ansari/resources/templates/password_reset.html
@@ -4,8 +4,8 @@
 
 <p>If you did not request a reset of your Ansari password, you can safely ignore this.</p>
 
-<p>Click on <a href="https://ansari.chat/reset-password?token={{reset_token}}">this link</a> to reset your password.</p>
+<p>Click on <a href="{{frontend_url}}/reset-password?token={{reset_token}}">this link</a> to reset your password.</p>
 
 Or paste this link into your browser:
 
-https://ansari.chat/reset-password?token={{reset_token}}
+{{frontend_url}}/reset-password?token={{reset_token}}


### PR DESCRIPTION
The reset password html template was hardcoded to use the production frontend URL https://ansari.chat which was breaking the reset password flow in the staging environment, this PR introduces a frontend env variable which can be adjusted across staging and prod (I have updated the AWS parameter store accordingly).