### PR TITLE
Fix ayah-claude endpoint and migrate to new Usul API URL

### DIFF
--- a/src/ansari/agents/ansari_claude.py
+++ b/src/ansari/agents/ansari_claude.py
@@ -22,16 +22,20 @@ logger = get_logger(__name__)
 class AnsariClaude(Ansari):
     """Claude-based implementation of the Ansari agent."""
 
-    def __init__(self, settings: Settings, message_logger: MessageLogger = None, json_format=False):
+    def __init__(self, settings: Settings, message_logger: MessageLogger = None, json_format=False, system_prompt_file=None):
         """Initialize the Claude-based Ansari agent.
 
         Args:
             settings: Application settings
             message_logger: Optional message logger instance
             json_format: Whether to use JSON format for responses
+            system_prompt_file: Optional system prompt file name (defaults to 'system_msg_claude')
         """
         # Call parent initialization
         super().__init__(settings, message_logger, json_format)
+        
+        # Set the system prompt file to use (can be overridden for specific use cases like ayah endpoint)
+        self.system_prompt_file = system_prompt_file or "system_msg_claude"
 
         # Log environment information for debugging
         try:
@@ -679,7 +683,7 @@ class AnsariClaude(Ansari):
         # 1. API REQUEST PREPARATION AND EXECUTION
         # ======================================================================
         prompt_mgr = PromptMgr()
-        system_prompt = prompt_mgr.bind("system_msg_claude").render()
+        system_prompt = prompt_mgr.bind(self.system_prompt_file).render()
 
         # Run pre-flight validation to ensure proper tool_use/tool_result relationship
         # This helps prevent API errors by fixing message structure before sending

--- a/src/ansari/app/main_api.py
+++ b/src/ansari/app/main_api.py
@@ -1131,19 +1131,10 @@ async def answer_ayah_question_claude(
         # Create AnsariClaude instance with ayah-specific system prompt
         logger.debug(f"Creating AnsariClaude instance for {req.surah}:{req.ayah}")
 
-        # Load the ayah-specific system prompt
-        system_prompt_path = os.path.join(
-            os.path.dirname(__file__), "..", "system_prompts", settings.AYAH_SYSTEM_PROMPT_FILE_NAME
-        )
-
-        with open(system_prompt_path, "r") as f:
-            ayah_system_prompt = f.read()
-
-        # Initialize AnsariClaude with the ayah-specific system prompt
+        # Initialize AnsariClaude with the ayah-specific system prompt file
         ansari_claude = AnsariClaude(
             settings,
-            system_prompt=ayah_system_prompt,
-            source_type=SourceType.WEB,  # Using WEB for now, could add QURAN_COM if needed
+            system_prompt_file=settings.AYAH_SYSTEM_PROMPT_FILE_NAME
         )
 
         # Prepare the context with ayah information

--- a/src/ansari/config.py
+++ b/src/ansari/config.py
@@ -167,7 +167,7 @@ class Settings(BaseSettings):
 
     # Usul.ai API settings
     USUL_API_TOKEN: SecretStr = Field(default="")  # Set via environment variable
-    USUL_BASE_URL: str = Field(default="https://semantic-search.usul.ai/v1/vector-search")
+    USUL_BASE_URL: str = Field(default="https://api.usul.ai/v1/vector-search")
     USUL_TOOL_NAME_PREFIX: str = Field(default="search_usul")
     TAFSIR_ENCYC_BOOK_ID: str = Field(default="pet7s2sjr900zvxjsafa3s3b")
     TAFSIR_ENCYC_VERSION_ID: str = Field(default="MT3i8pDNoM")

--- a/tests/unit/test_ansari_claude_system_prompt.py
+++ b/tests/unit/test_ansari_claude_system_prompt.py
@@ -1,0 +1,151 @@
+"""Unit tests for AnsariClaude system_prompt_file parameter."""
+
+import pytest
+from unittest.mock import MagicMock, patch, mock_open
+import anthropic
+
+
+@pytest.fixture
+def mock_settings():
+    """Mock settings for testing."""
+    settings = MagicMock()
+    settings.ANTHROPIC_API_KEY = MagicMock()
+    settings.ANTHROPIC_API_KEY.get_secret_value.return_value = "test-api-key"
+    settings.ANTHROPIC_MODEL = "claude-3-opus-20240229"
+    settings.KALEMAT_API_KEY = MagicMock()
+    settings.KALEMAT_API_KEY.get_secret_value.return_value = "test-kalemat-key"
+    settings.VECTARA_API_KEY = MagicMock()
+    settings.VECTARA_API_KEY.get_secret_value.return_value = "test-vectara-key"
+    settings.MAWSUAH_VECTARA_CORPUS_KEY = "test-corpus-key"
+    settings.TAFSIR_VECTARA_CORPUS_KEY = "test-tafsir-key"
+    settings.USUL_API_TOKEN = MagicMock()
+    settings.USUL_API_TOKEN.get_secret_value.return_value = "test-usul-token"
+    settings.MODEL = "test-model"
+    settings.PROMPT_PATH = "/test/prompts"
+    settings.SYSTEM_PROMPT_FILE_NAME = "system_msg_default"
+    settings.AYAH_SYSTEM_PROMPT_FILE_NAME = "system_msg_ayah"
+    return settings
+
+
+class TestAnsariClaudeSystemPrompt:
+    """Test AnsariClaude system prompt file parameter."""
+
+    def test_default_system_prompt_file(self, mock_settings):
+        """Test that AnsariClaude uses default system prompt file when not specified."""
+        with patch("anthropic.Anthropic"), \
+             patch("src.ansari.util.prompt_mgr.PromptMgr") as mock_prompt_mgr:
+            # Mock the prompt manager
+            mock_prompt = MagicMock()
+            mock_prompt.render.return_value = "Test system prompt"
+            mock_prompt_mgr.return_value.bind.return_value = mock_prompt
+            
+            from src.ansari.agents.ansari_claude import AnsariClaude
+            
+            # Initialize without system_prompt_file parameter
+            ansari = AnsariClaude(mock_settings)
+            
+            # Verify default is used
+            assert ansari.system_prompt_file == "system_msg_claude"
+
+    def test_custom_system_prompt_file(self, mock_settings):
+        """Test that AnsariClaude uses custom system prompt file when specified."""
+        with patch("anthropic.Anthropic"), \
+             patch("src.ansari.util.prompt_mgr.PromptMgr") as mock_prompt_mgr:
+            # Mock the prompt manager
+            mock_prompt = MagicMock()
+            mock_prompt.render.return_value = "Test system prompt"
+            mock_prompt_mgr.return_value.bind.return_value = mock_prompt
+            
+            from src.ansari.agents.ansari_claude import AnsariClaude
+            
+            # Initialize with custom system_prompt_file
+            ansari = AnsariClaude(mock_settings, system_prompt_file="system_msg_ayah")
+            
+            # Verify custom file is used
+            assert ansari.system_prompt_file == "system_msg_ayah"
+
+    def test_system_prompt_loaded_in_process_one_round(self, mock_settings):
+        """Test that the correct system prompt file is loaded during process_one_round."""
+        with patch("anthropic.Anthropic") as mock_anthropic:
+            # Mock the Anthropic client
+            mock_client = MagicMock()
+            mock_anthropic.return_value = mock_client
+            
+            # Mock the response stream
+            mock_response = MagicMock()
+            mock_response.__iter__ = MagicMock(return_value=iter([]))
+            mock_client.messages.create.return_value = mock_response
+            
+            from src.ansari.agents.ansari_claude import AnsariClaude
+            from src.ansari.util.prompt_mgr import PromptMgr
+            
+            # Initialize with custom system prompt file
+            ansari = AnsariClaude(mock_settings, system_prompt_file="system_msg_ayah")
+            
+            # Add a message to history
+            ansari.message_history = [{"role": "user", "content": "test question"}]
+            
+            # Mock PromptMgr to verify the correct file is loaded
+            with patch.object(PromptMgr, 'bind') as mock_bind:
+                mock_prompt = MagicMock()
+                mock_prompt.render.return_value = "Test ayah system prompt"
+                mock_bind.return_value = mock_prompt
+                
+                # Call process_one_round
+                result = list(ansari.process_one_round())
+                
+                # Verify the correct system prompt file was loaded
+                mock_bind.assert_called_with("system_msg_ayah")
+
+    def test_ayah_endpoint_initialization(self, mock_settings):
+        """Test that the ayah-claude endpoint can initialize AnsariClaude with custom system prompt."""
+        with patch("anthropic.Anthropic"):
+            from src.ansari.agents.ansari_claude import AnsariClaude
+            
+            # Simulate ayah endpoint initialization
+            ansari = AnsariClaude(
+                mock_settings,
+                system_prompt_file=mock_settings.AYAH_SYSTEM_PROMPT_FILE_NAME
+            )
+            
+            # Verify the ayah system prompt file is used
+            assert ansari.system_prompt_file == "system_msg_ayah"
+
+    def test_process_one_round_with_different_prompts(self, mock_settings):
+        """Test that different system prompts are used based on initialization."""
+        with patch("anthropic.Anthropic") as mock_anthropic:
+            # Mock the Anthropic client
+            mock_client = MagicMock()
+            mock_anthropic.return_value = mock_client
+            
+            # Mock the response stream
+            mock_response = MagicMock()
+            mock_response.__iter__ = MagicMock(return_value=iter([]))
+            mock_client.messages.create.return_value = mock_response
+            
+            from src.ansari.agents.ansari_claude import AnsariClaude
+            from src.ansari.util.prompt_mgr import PromptMgr
+            
+            # Test with default prompt
+            ansari_default = AnsariClaude(mock_settings)
+            ansari_default.message_history = [{"role": "user", "content": "test"}]
+            
+            with patch.object(PromptMgr, 'bind') as mock_bind:
+                mock_prompt = MagicMock()
+                mock_prompt.render.return_value = "Default system prompt"
+                mock_bind.return_value = mock_prompt
+                
+                list(ansari_default.process_one_round())
+                mock_bind.assert_called_with("system_msg_claude")
+            
+            # Test with ayah prompt
+            ansari_ayah = AnsariClaude(mock_settings, system_prompt_file="system_msg_ayah")
+            ansari_ayah.message_history = [{"role": "user", "content": "test"}]
+            
+            with patch.object(PromptMgr, 'bind') as mock_bind:
+                mock_prompt = MagicMock()
+                mock_prompt.render.return_value = "Ayah system prompt"
+                mock_bind.return_value = mock_prompt
+                
+                list(ansari_ayah.process_one_round())
+                mock_bind.assert_called_with("system_msg_ayah")

--- a/tests/unit/test_ayah_claude_fix.py
+++ b/tests/unit/test_ayah_claude_fix.py
@@ -1,0 +1,98 @@
+"""Integration test to verify the ayah-claude endpoint fix."""
+
+from unittest.mock import patch, MagicMock
+import os
+import tempfile
+
+
+def test_ayah_claude_endpoint_loads_correct_system_prompt():
+    """Test that the ayah-claude endpoint loads the system prompt correctly using PromptMgr."""
+    
+    # Create a temporary system prompt file
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create the prompts directory structure
+        prompts_dir = os.path.join(tmpdir, "prompts")
+        os.makedirs(prompts_dir)
+        
+        # Create test prompt files
+        default_prompt_file = os.path.join(prompts_dir, "system_msg_default.txt")
+        claude_prompt_file = os.path.join(prompts_dir, "system_msg_claude.txt")
+        ayah_prompt_file = os.path.join(prompts_dir, "system_msg_ayah.txt")
+        
+        with open(default_prompt_file, "w") as f:
+            f.write("Default system prompt")
+        with open(claude_prompt_file, "w") as f:
+            f.write("Claude system prompt")
+        with open(ayah_prompt_file, "w") as f:
+            f.write("Ayah system prompt for Quranic questions")
+            
+        # Mock settings
+        mock_settings = MagicMock()
+        mock_settings.ANTHROPIC_API_KEY.get_secret_value.return_value = "test-key"
+        mock_settings.ANTHROPIC_MODEL = "claude-3-opus-20240229"
+        mock_settings.KALEMAT_API_KEY.get_secret_value.return_value = "test-key"
+        mock_settings.VECTARA_API_KEY.get_secret_value.return_value = "test-key"
+        mock_settings.USUL_API_TOKEN.get_secret_value.return_value = "test-key"
+        mock_settings.MAWSUAH_VECTARA_CORPUS_KEY = "test-corpus"
+        mock_settings.TAFSIR_VECTARA_CORPUS_KEY = "test-tafsir"
+        mock_settings.MODEL = "test-model"
+        mock_settings.PROMPT_PATH = prompts_dir
+        mock_settings.SYSTEM_PROMPT_FILE_NAME = "system_msg_default"
+        mock_settings.AYAH_SYSTEM_PROMPT_FILE_NAME = "system_msg_ayah"
+        
+        # Patch Anthropic client
+        with patch("anthropic.Anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.return_value = mock_client
+            
+            from src.ansari.agents.ansari_claude import AnsariClaude
+            
+            # Test 1: Default initialization should use system_msg_claude
+            ansari_default = AnsariClaude(mock_settings)
+            assert ansari_default.system_prompt_file == "system_msg_claude"
+            
+            # Test 2: Initialization with ayah system prompt
+            ansari_ayah = AnsariClaude(
+                mock_settings,
+                system_prompt_file=mock_settings.AYAH_SYSTEM_PROMPT_FILE_NAME
+            )
+            assert ansari_ayah.system_prompt_file == "system_msg_ayah"
+            
+            # Test 3: Verify process_one_round uses the correct prompt file
+            # Mock the API response
+            mock_response = MagicMock()
+            mock_response.__iter__ = MagicMock(return_value=iter([]))
+            mock_client.messages.create.return_value = mock_response
+            
+            # Add a message to process
+            ansari_ayah.message_history = [{"role": "user", "content": "test question"}]
+            
+            # Process the message
+            list(ansari_ayah.process_one_round())
+            
+            # Verify the API was called with the ayah system prompt
+            api_call_args = mock_client.messages.create.call_args
+            if api_call_args:
+                system_prompt = api_call_args.kwargs.get("system", [{}])[0].get("text", "")
+                # The system prompt should be loaded from the ayah file
+                # We can't check the exact content without actually loading the file,
+                # but we can verify the API was called
+                assert mock_client.messages.create.called
+
+
+def test_ansari_claude_accepts_system_prompt_file_parameter():
+    """Test that AnsariClaude constructor accepts system_prompt_file parameter."""
+    
+    # This test verifies the signature change without needing to mock all dependencies
+    from inspect import signature
+    from src.ansari.agents.ansari_claude import AnsariClaude
+    
+    # Get the signature of the __init__ method
+    sig = signature(AnsariClaude.__init__)
+    
+    # Check that system_prompt_file is a parameter
+    assert "system_prompt_file" in sig.parameters
+    
+    # Check that it has a default value of None
+    param = sig.parameters["system_prompt_file"]
+    assert param.default is None


### PR DESCRIPTION
- Fix FileNotFoundError in /api/v2/ayah-claude endpoint by using PromptMgr
- Add system_prompt_file parameter to AnsariClaude for configurable prompts
- Update process_one_round to use configurable system prompt file
- Migrate Usul API URL from semantic-search.usul.ai to api.usul.ai
- Add comprehensive tests for system prompt file functionality

Fixes:
- Internal server error (500) on ayah-claude endpoint
- SSL certificate error (526) with old Usul API domain